### PR TITLE
Omit function type as first argument on 0.5

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,12 +3,19 @@ using Base.Test
 
 if VERSION >= v"0.5.0-dev"
     # Function as argument
-    keep, pcstring, fpath, args = SnoopCompile.parse_call("Base.any($(typeof(identity)), Array{Bool, 1})")
+    str = "Base.any($(typeof(identity)), Array{Bool, 1})"
+    keep, pcstring, fpath, args = SnoopCompile.parse_call(str)
     @test keep
     @test pcstring == "    precompile(Base.any, (typeof(Base.identity), Array{Bool, 1},))"
     # Anonymous function as argument
-    keep, pcstring, fpath, args = SnoopCompile.parse_call("Base.any($(typeof(x->x>0)), Array{Float32, 1})")
+    str = "Base.any($(typeof(x->x>0)), Array{Float32, 1})"
+    keep, pcstring, fpath, args = SnoopCompile.parse_call(str)
     @test !keep
+    # Function as a type
+    str = "Base.Sort.sort!(Base.#sort!, Array{Any, 1}, Base.Sort.MergeSortAlg, Base.Order.By{Base.#string})"
+    keep, pcstring, fpath, args = SnoopCompile.parse_call(str)
+    @test keep
+    @test pcstring == "    precompile(Base.Sort.sort!, (Array{Any, 1}, Base.Sort.MergeSortAlg, Base.Order.By{typeof(Base.string)},))"
 end
 
 include("colortypes.jl")


### PR DESCRIPTION
This seems to be another necessary julia-0.5 fix.