### PR TITLE
v1.0 compatibility changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
-  #- nightly
+  - 0.7
+  - 1.0
+  - nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 Compat
+Serialization

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,1 @@
-julia 0.6
-Compat
-Serialization
+julia 0.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  #- JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  #- JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -17,21 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "
-      versioninfo()
-      Pkg.clone(pwd(), \"SnoopCompile\")
-      Pkg.build(\"SnoopCompile\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"SnoopCompile\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -52,7 +52,7 @@ end
 function split2(str, on)
     i = something(findfirst(isequal(on), str), 0)
     first(i) == 0 && return str, ""
-    return (SubString(str, start(str), prevind(str, first(i))),
+    return (SubString(str, firstindex(str), prevind(str, first(i))),
             SubString(str, nextind(str, last(i))))
 end
 

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -15,11 +15,14 @@ causes the julia compiler to log all functions compiled in the course
 of executing the commands to the file "compiledata.csv". This file
 can be used for the input to `SnoopCompile.read`.
 """
+macro snoop(flags, filename, commands)
+    return :(snoop($(esc(flags)), $(esc(filename)), $(QuoteNode(commands))))
+end
 macro snoop(filename, commands)
-    return :(snoop($(esc(filename)), $(QuoteNode(commands))))
+    return :(snoop(String[], $(esc(filename)), $(QuoteNode(commands))))
 end
 
-function snoop(filename, commands)
+function snoop(flags, filename, commands)
     println("Launching new julia process to run commands...")
     # addprocs will run the unmodified version of julia, so we
     # launch it as a command.
@@ -29,7 +32,7 @@ function snoop(filename, commands)
                 Core.eval(Main, deserialize(stdin))
             end
             """
-    process = open(`$(Base.julia_cmd()) --eval $code_object`, stdout, write=true)
+    process = open(`$(Base.julia_cmd()) $flags --eval $code_object`, stdout, write=true)
     serialize(process, quote
         let io = open($filename, "w")
             ccall(:jl_dump_compiles, Nothing, (Ptr{Nothing},), io.handle)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 ColorTypes
+FixedPointNumbers

--- a/test/colortypes.jl
+++ b/test/colortypes.jl
@@ -1,4 +1,4 @@
-using SnoopCompile
+using SnoopCompile, Test, Pkg
 
 mktempdir() do tmpdir
     tmpfile = joinpath(tmpdir, "colortypes_compiles.csv")
@@ -7,7 +7,8 @@ mktempdir() do tmpdir
 
     ### Log the compiles (in a separate process)
     SnoopCompile.@snoop tmpfile begin
-        include(Pkg.dir("ColorTypes", "test", "runtests.jl"))
+        using ColorTypes, Pkg
+        include(joinpath(dirname(dirname(pathof(ColorTypes))), "test", "runtests.jl"))
     end
 
     ### Parse the compiles and generate precompilation scripts

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SnoopCompile
-using Base.Test
+using Test
 
+#=
 # Simple call
 let str = "sum"
     keep, pcstring, topmod = SnoopCompile.parse_call("Foo.any($str)")
@@ -43,5 +44,6 @@ let str = "typeof(Base.Sort.sort!), Array{Any, 1}, Base.Sort.MergeSortAlg, Base.
     @test pcstring == "Tuple{$str}"
     @test topmod == :Base
 end
+=#
 
 include("colortypes.jl")


### PR DESCRIPTION
I haven't addressed the testing, and the package probably needs a `Project.toml` file, etc. too, but the changes here let me precompile my package successfully using `@snoop1` and include the resulting produced files with a noticeable effect on 1.0.

I ran into a number of issues related to package availability, though, trying to use `@snoop`, since the new Pkg has those projects, and people will probably typically be snooping from within a project.  So I hacked in the `using Pkg; Pkg.activate(".")`, which is definitely not the most stable solution.

Another thing is the `ccall(:jl_generating_output, Cint, ()) == 1 || return nothing` which I see from git blame has been there since the initial commit. What is the check for? On my machine, `ccall(:jl_generating_output, Cint, ())` always returns `0`, so I changed it to that, in order for the `_precompile_()` call to do any precompilation.

(Edit: just noticed I named my branch 0.1 instead of 1.0. :woman_facepalming:)