### PR TITLE
Parse `where` signatures (fixes #20)

### DIFF
--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -117,7 +117,10 @@ function parse_call(line; subst=Vector{Pair{String, String}}(), blacklist=String
         return false, line, :unknown
     end
 
-    curly = Meta.parse(line, raise=false)
+    curly = ex = Meta.parse(line, raise=false)
+    while Meta.isexpr(curly, :where)
+        curly = curly.args[1]
+    end
     if !Meta.isexpr(curly, :curly)
         @warn("failed parse of line: ", line)
         return false, line, :unknown
@@ -153,7 +156,7 @@ function parse_call(line; subst=Vector{Pair{String, String}}(), blacklist=String
     # In Julia 0.6, functions with symbolic names like `Base.:(+)` don't output correctly.
     # So if we didn't change the arg list above, use the original string.
     if changed
-        line = string(curly)
+        line = string(ex)
     end
     return true, line, topmod
 end

--- a/test/colortypes.jl
+++ b/test/colortypes.jl
@@ -1,35 +1,41 @@
 using SnoopCompile, Test, Pkg
 
-mktempdir() do tmpdir
-    tmpfile = joinpath(tmpdir, "colortypes_compiles.csv")
-    tmpdir2 = joinpath(tmpdir, "precompile")
-    tmpfile2 = joinpath(tmpdir, "userimg_ColorTypes.jl")
+@testset "ColorTypes" begin
+    success, line, modsym = SnoopCompile.parse_call("Tuple{typeof(ColorTypes.to_top), Type{C}} where C<:(ColorTypes.Colorant{T, N} where N where T)")
+    @test success
+    @test modsym == :ColorTypes
 
-    ### Log the compiles (in a separate process)
-    SnoopCompile.@snoop tmpfile begin
-        using ColorTypes, Pkg
-        include(joinpath(dirname(dirname(pathof(ColorTypes))), "test", "runtests.jl"))
+    mktempdir() do tmpdir
+        tmpfile = joinpath(tmpdir, "colortypes_compiles.csv")
+        tmpdir2 = joinpath(tmpdir, "precompile")
+        tmpfile2 = joinpath(tmpdir, "userimg_ColorTypes.jl")
+
+        ### Log the compiles (in a separate process)
+        SnoopCompile.@snoop tmpfile begin
+            using ColorTypes, Pkg
+            include(joinpath(dirname(dirname(pathof(ColorTypes))), "test", "runtests.jl"))
+        end
+
+        ### Parse the compiles and generate precompilation scripts
+        let data = SnoopCompile.read(tmpfile)
+            # Use these two lines if you want to create precompile functions for
+            # individual packages
+            pc = SnoopCompile.parcel(reverse!(data[2]))
+            SnoopCompile.write(tmpdir2, pc)
+
+            # Use these two lines if you want to add to your userimg.jl
+            pc = SnoopCompile.format_userimg(reverse!(data[2]))
+            SnoopCompile.write(tmpfile2, pc)
+        end
+
+        function notisempty(filename, minlength)
+            @test isfile(filename)
+            @test length(readlines(filename)) >= minlength
+            nothing
+        end
+
+        notisempty(joinpath(tmpdir2, "precompile_ColorTypes.jl"), 100)
+        notisempty(joinpath(tmpdir2, "precompile_FixedPointNumbers.jl"), 2)
+        notisempty(tmpfile2, 100)
     end
-
-    ### Parse the compiles and generate precompilation scripts
-    let data = SnoopCompile.read(tmpfile)
-        # Use these two lines if you want to create precompile functions for
-        # individual packages
-        pc = SnoopCompile.parcel(reverse!(data[2]))
-        SnoopCompile.write(tmpdir2, pc)
-
-        # Use these two lines if you want to add to your userimg.jl
-        pc = SnoopCompile.format_userimg(reverse!(data[2]))
-        SnoopCompile.write(tmpfile2, pc)
-    end
-
-    function notisempty(filename, minlength)
-        @test isfile(filename)
-        @test length(readlines(filename)) >= minlength
-        nothing
-    end
-
-    notisempty(joinpath(tmpdir2, "precompile_ColorTypes.jl"), 100)
-    notisempty(joinpath(tmpdir2, "precompile_FixedPointNumbers.jl"), 2)
-    notisempty(tmpfile2, 100)
 end


### PR DESCRIPTION
Fixes #20, CC @vtjnash 