### PR TITLE
check that functions in precompile lists are defined

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,9 @@ julia = "0.7, 1"
 [extras]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+JLD = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Pkg", "ColorTypes", "Test", "FixedPointNumbers"]
+test = ["Pkg", "ColorTypes", "Test", "FixedPointNumbers", "JLD"]

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -245,7 +245,7 @@ function parcel(calls; subst=Vector{Pair{String, String}}(), blacklist=String[])
         if !haskey(pc, topmod)
             pc[topmod] = String[]
         end
-        prefix = (isempty(name) ? "" : "isdefined($topmod, :$name) && ")
+        prefix = (isempty(name) ? "" : "isdefined($topmod, Symbol(\"$name\")) && ")
         push!(pc[topmod], prefix * "precompile($pcstring)")
     end
     return pc
@@ -259,8 +259,8 @@ function format_userimg(calls; subst=Vector{Pair{String, String}}(), blacklist=S
     for c in calls
         keep, pcstring, topmod, name = parse_call(c, subst=subst, blacklist=blacklist)
         keep || continue
-        prefix = (isempty(name) ? "" : "isdefined($topmod, :$name) && ")
-        push!(pc[topmod], prefix * "precompile($pcstring)")
+        prefix = (isempty(name) ? "" : "isdefined($topmod, Symbol(\"$name\")) && ")
+        push!(pc, prefix * "precompile($pcstring)")
     end
     return pc
 end

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -180,7 +180,7 @@ function parse_call(line; subst=Vector{Pair{String, String}}(), blacklist=String
     end
     if any(b -> occursin(b, line), blacklist)
         println(line, " contains a blacklisted substring")
-        return false, line, :unknown
+        return false, line, :unknown, ""
     end
 
     curly = ex = Meta.parse(line, raise=false)
@@ -189,7 +189,7 @@ function parse_call(line; subst=Vector{Pair{String, String}}(), blacklist=String
     end
     if !Meta.isexpr(curly, :curly)
         @warn("failed parse of line: ", line)
-        return false, line, :unknown
+        return false, line, :unknown, ""
     end
     func = curly.args[2]
     topmod = (func isa Expr ? extract_topmod(func) : :Main)

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -174,7 +174,7 @@ end
 const anonrex = r"##\d*#{1,2}\d*"   # detect anonymous functions
 
 function parse_call(line; subst=Vector{Pair{String, String}}(), blacklist=String[])
-    match(anonrex, line) === nothing || return false, line, :unknown
+    match(anonrex, line) === nothing || return false, line, :unknown, ""
     for (k, v) in subst
         line = replace(line, k=>v)
     end
@@ -193,6 +193,9 @@ function parse_call(line; subst=Vector{Pair{String, String}}(), blacklist=String
     end
     func = curly.args[2]
     topmod = (func isa Expr ? extract_topmod(func) : :Main)
+
+    check = Meta.isexpr(func, :call) && length(func.args) == 3 && func.args[1] == :getfield
+    name = (check ? func.args[3].args[2] : "")
 
     # make some substitutions to try to form a leaf types tuple
     changed = false
@@ -224,7 +227,7 @@ function parse_call(line; subst=Vector{Pair{String, String}}(), blacklist=String
     if changed
         line = string(ex)
     end
-    return true, line, topmod
+    return true, line, topmod, name
 end
 
 """
@@ -236,13 +239,14 @@ function parcel(calls; subst=Vector{Pair{String, String}}(), blacklist=String[])
     pc = Dict{Symbol, Vector{String}}()
     for c in calls
         local keep, pcstring, topmod
-        keep, pcstring, topmod = parse_call(c, subst=subst, blacklist=blacklist)
+        keep, pcstring, topmod, name = parse_call(c, subst=subst, blacklist=blacklist)
         keep || continue
         # Add to the appropriate dictionary
         if !haskey(pc, topmod)
             pc[topmod] = String[]
         end
-        push!(pc[topmod], "precompile($pcstring)")
+        prefix = (isempty(name) ? "" : "isdefined($topmod, :$name) && ")
+        push!(pc[topmod], prefix * "precompile($pcstring)")
     end
     return pc
 end
@@ -253,9 +257,10 @@ end
 function format_userimg(calls; subst=Vector{Pair{String, String}}(), blacklist=String[])
     pc = Vector{String}()
     for c in calls
-        keep, pcstring, topmod = parse_call(c, subst=subst, blacklist=blacklist)
+        keep, pcstring, topmod, name = parse_call(c, subst=subst, blacklist=blacklist)
         keep || continue
-        push!(pc, "precompile($pcstring)")
+        prefix = (isempty(name) ? "" : "isdefined($topmod, :$name) && ")
+        push!(pc[topmod], prefix * "precompile($pcstring)")
     end
     return pc
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using SnoopCompile
+using JLD
+using SparseArrays
 using Test
 
 uncompiled(x) = x + 1
@@ -22,6 +24,21 @@ end
 data = SnoopCompile.read("/tmp/anon.log")
 pc = SnoopCompile.parcel(reverse!(data[2]))
 @test length(pc[:Base]) <= 1
+
+# issue #29
+keep, pcstring, topmod, name = SnoopCompile.parse_call("Tuple{getfield(JLD, Symbol(\"##s27#8\")), Any, Any, Any, Any, Any}")
+@test keep == true
+@test pcstring == "Tuple{getfield(JLD, Symbol(\"##s27#8\")), Int, Int, Int, Int, Int}"
+@test topmod == :JLD
+@test name == "##s27#8"
+# save("/tmp/mat.jld", "mat", sprand(10, 10, 0.1))
+# @snoopc "/tmp/jldanon.log" begin
+#     using JLD, SparseArrays
+#     mat = load("/tmp/mat.jld", "mat")
+# end
+# data = SnoopCompile.read("/tmp/jldanon.log")
+# pc = SnoopCompile.parcel(reverse!(data[2]))
+# pc[:JLD]
 
 #=
 # Simple call

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,14 +31,14 @@ keep, pcstring, topmod, name = SnoopCompile.parse_call("Tuple{getfield(JLD, Symb
 @test pcstring == "Tuple{getfield(JLD, Symbol(\"##s27#8\")), Int, Int, Int, Int, Int}"
 @test topmod == :JLD
 @test name == "##s27#8"
-# save("/tmp/mat.jld", "mat", sprand(10, 10, 0.1))
-# @snoopc "/tmp/jldanon.log" begin
-#     using JLD, SparseArrays
-#     mat = load("/tmp/mat.jld", "mat")
-# end
-# data = SnoopCompile.read("/tmp/jldanon.log")
-# pc = SnoopCompile.parcel(reverse!(data[2]))
-# pc[:JLD]
+save("/tmp/mat.jld", "mat", sprand(10, 10, 0.1))
+@snoopc "/tmp/jldanon.log" begin
+    using JLD, SparseArrays
+    mat = load("/tmp/mat.jld", "mat")
+end
+data = SnoopCompile.read("/tmp/jldanon.log")
+pc = SnoopCompile.parcel(reverse!(data[2]))
+@test any(startswith.(pc[:JLD], "isdefined"))
 
 #=
 # Simple call


### PR DESCRIPTION
Addresses #29 

This works for the [example](https://gist.github.com/lkapelevich/e4f539e7da084240a3c49a76554eb0bc) in the issue, but I'm not sure I have implemented it in the most effective way, or what the best way to test this is. If `func` (https://github.com/timholy/SnoopCompile.jl/blob/master/src/SnoopCompile.jl#L194) looks like 
`:(getfield(mod, Symbol("##...#..")))`, we add a check `isdefined(mod, "##...#..")`.