### PR TITLE
Automate atsign-snoopi similar to snoopc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ compilation in packages.
 
 ## Usage
 
-### Snooping on inference
+### Snooping on inference (recommended)
 
 Currently precompilation only saves inferred code; consequently, the time spent on type inference
 is probably the most relevant concern. To learn how much time is spent on each method instance
@@ -21,12 +21,135 @@ when executing a command `cmd`, do something like the following (note: requires 
 using SnoopCompile
 
 a = rand(Float16, 5)
-inf_timing = @snoopi tmin=0.01 sum(a)
+
+julia> inf_timing = @snoopi tmin=0.01 sum(a)
+1-element Array{Tuple{Float64,Core.MethodInstance},1}:
+ (0.011293888092041016, MethodInstance for sum(::Array{Float16,1}))
 ```
+
+Here, we filtered out methods that took less than 10ms to compile via `tmin=0.01`.
+We can see that only one method took longer than this (and if your machine is faster than
+mine, `inf_timing` might even be empty with these settings).
+You can see the specific `MethodInstance` that got compiled.
+Note that
+
+```julia
+julia> @which sum(a)
+sum(a::AbstractArray) in Base at reducedim.jl:652
+```
+
+indicates that the method is much more general (i.e., defined for `AbstractArray`)
+than the instance (defined for `Array{Float16,1}`); precompilation works on the concrete
+types of the objects passed as arguments.
+
+You can use `@snoopi` to come up with a list of precompile-worthy functions.
+A recommended approach is to write a script that "exercises" the functionality
+you'd like to precompile.
+One option is to use your package's `"runtests.jl"` file, or you can write a custom
+script for this purpose.
+Here's an example for the
+[FixedPointNumbers package](https://github.com/JuliaMath/FixedPointNumbers.jl):
+
+```
+using FixedPointNumbers
+
+x = N0f8(0.2)
+y = x + x
+y = x - x
+y = x*x
+y = x/x
+y = Float32(x)
+y = Float64(x)
+y = 0.3*x
+y = x*0.3
+y = 2*x
+y = x*2
+y = x/15
+y = x/8.0
+```
+
+Save this as a file `"snoopfpn.jl"` and navigate at the Julia REPL to that directory,
+and then do
+
+```julia
+julia> using SnoopCompile
+
+julia> inf_timing = @snoopi tmin=0.01 include("snoopfpn.jl")
+3-element Array{Tuple{Float64,Core.MethodInstance},1}:
+ (0.016037940979003906, MethodInstance for *(::Float64, ::Normed{UInt8,8}))        
+ (0.028206825256347656, MethodInstance for *(::Normed{UInt8,8}, ::Normed{UInt8,8}))
+ (0.0369410514831543, MethodInstance for Normed{UInt8,8}(::Float64))               
+```
+
+SnoopCompile contains utilities that for generating precompile files that can be `include`d into
+package(s):
+
+```julia
+ julia> pc = SnoopCompile.parcel(inf_timing)
+ Dict{Symbol,Array{String,1}} with 1 entry:
+   :FixedPointNumbers => ["precompile(Tuple{typeof(*),Float64,Normed{UInt8,8}})", "precompile(Tuple{typeof(*),Normed{UInt8,8},Normed{UInt8,8}})", "precompile(Tuple{Type{Normed{UInt8,8}},Float64})"]
+
+ julia> SnoopCompile.write("/tmp/precompile", pc)
+```
+
+This splits the calls up into a dictionary, `pc`, indexed by the package which "owns"
+each call.
+(In this case there is only one, `FixedPointNumbers`, but in more complex cases there may
+be several.) If you then look in the `/tmp/precompile` directory, you'll see one or more
+files, named by their parent package, that may be suitable for `include`ing into your
+module definition(s).
+These may or may not reduce the time for your package to execute similar operations.
+
+While this "automated" approach is often useful, sometimes it makes more sense to
+inspect the results and write your own precompile directives.
+For example, for FixedPointNumbers a more elegant precompile file could be
+
+```julia
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    for T in (N0f8, N0f16)      # Normed types we want to support
+        for f in (+, -, *, /)   # operations we want to support
+            precompile(Tuple{typeof(f),T,T})
+            for S in (Float32, Float64, Int)   # other number types we want to support
+                precompile(Tuple{typeof(f),T,S})
+                precompile(Tuple{typeof(f),S,T})
+            end
+        end
+        for S in (Float32, Float64)
+            precompile(Tuple{Type{T},S})
+            precompile(Tuple{Type{S},T})
+        end
+    end
+end
+```
+
+This covers `+`, `-`, `*`, `/`, and conversion for various combinations of types.
+The results from `@snoopi` can suggest method/type combinations that might be useful to
+precompile, but often you can generalize its suggestions in useful ways.
+
+If you `include` a precompile file into your package definition and then run the same
+`@snoopi` command again, hopefully it will omit many of the MethodInstances
+you obtained previously.
+This is a sign of success.
+Unfortunately, at present Julia has some significant limitations in terms of how
+extensively it can cache inference results, so you may not see as many of these
+methods "disappear" as you might hope.
+
+**NOTE**: if you later modify your code so that some of the methods no longer
+exist, `precompile` will *not* throw an error; it will instead fail silently.
+If you want to be certain that your precompile directives don't go stale,
+preface each with an `@assert`.
+Note that this forces you to update your precompile directives as you modify your package,
+which may or may not be desirable.
 
 ### Snooping on the compiler
 
-The easiest way to describe SnoopCompile is to show a snoop script, in this case for the `ColorTypes` package:
+SnoopCompile can also snoop on native code generation using a macro `@snoopc`,
+and thereby also determine what methods are being compiled.
+Note that native code is not cached, so this approach may not prioritize the most
+most useful methods in the same way that `@snoopi` does.
+
+Here's let's demonstrate `@snoopc` with a snoop script, in this case for the `ColorTypes` package:
 
 ```julia
 using SnoopCompile

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -233,12 +233,77 @@ function parse_call(line; subst=Vector{Pair{String, String}}(), blacklist=String
     return true, line, topmod, name
 end
 
+function topmodule(mods)
+    function ischild(c, mod)
+        ok = false
+        pc = parentmodule(c)
+        while pc !== c
+            pc === Main && return false  # mostly important for passing the tests
+            if isdefined(mod, nameof(pc))
+                ok = true
+                break
+            end
+            c = pc
+        end
+        return ok
+    end
+
+    mods = collect(mods)
+    mod = first(mods)
+    for m in Iterators.drop(mods, 1)
+        # Easy cases
+        if isdefined(mod, nameof(m))
+        elseif isdefined(m, nameof(mod))
+            mod = m
+        else
+            # Check parents of each
+            if ischild(m, mod)
+            elseif ischild(mod, m)
+                mod = m
+            else
+                return nothing
+            end
+        end
+    end
+    return mod
+end
+
+function parcel(tinf::AbstractVector{Tuple{Float64,Core.MethodInstance}}; subst=Vector{Pair{String, String}}(), blacklist=String[])
+    pc = Dict{Symbol, Vector{String}}()
+    mods = Set{Module}()
+    for (t, mi) in tinf
+        isdefined(mi, :specTypes) || continue
+        tt = mi.specTypes
+        empty!(mods)
+        push!(mods, Base.moduleroot(mi.def.module))
+        ok = true
+        for p in tt.parameters
+            if isa(p, DataType)
+                if match(anonrex, String(p.name.name)) !== nothing
+                    ok = false
+                    break
+                end
+                push!(mods, Base.moduleroot(p.name.module))
+            end
+        end
+        ok || continue
+        topmod = topmodule(mods)
+        topmod === nothing && continue
+        topmodname = nameof(topmod)
+        if !haskey(pc, topmodname)
+            pc[topmodname] = String[]
+        end
+        push!(pc[topmodname], "precompile(" * repr(tt) * ')')
+    end
+    return pc
+end
+
 """
 `pc = parcel(calls; subst=[], blacklist=[])` assigns each compile statement to the module that owns the function. Perform string substitution via `subst=["Module1"=>"Module2"]`, and omit functions in particular modules with `blacklist=["Module3"]`. On output, `pc[:Module2]` contains all the precompiles assigned to `Module2`.
 
 Use `SnoopCompile.write(prefix, pc)` to generate a series of files in directory `prefix`, one file per module.
 """
-function parcel(calls; subst=Vector{Pair{String, String}}(), blacklist=String[])
+function parcel(calls::AbstractVector{String}; subst=Vector{Pair{String, String}}(), blacklist=String[])
     pc = Dict{Symbol, Vector{String}}()
     for c in calls
         local keep, pcstring, topmod

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,26 @@ using JLD
 using SparseArrays
 using Test
 
+module A
+    module B
+        module C
+        end
+        module D
+        end
+    end
+end
+
+@testset "topmodule" begin
+    # topmod is called on moduleroots but nevertheless this is a useful test
+    @test SnoopCompile.topmodule([A, A.B]) === A
+    @test SnoopCompile.topmodule([A, A.B.C]) === A
+    @test SnoopCompile.topmodule([A.B, A]) === A
+    @test SnoopCompile.topmodule([A.B.C, A]) === A
+    @test SnoopCompile.topmodule([A.B.C, A.B.D]) === nothing
+    @test SnoopCompile.topmodule([A, Base]) === A
+    @test SnoopCompile.topmodule([Base, A]) === A
+end
+
 uncompiled(x) = x + 1
 if VERSION >= v"1.2.0-DEV.573"
     include_string(Main, """
@@ -13,6 +33,8 @@ if VERSION >= v"1.2.0-DEV.573"
         a = rand(Float16, 5)
         timing_data = @snoopi sum(a)
         @test any(td->td[2].def.name == :sum, timing_data)
+        pc = SnoopCompile.parcel(timing_data)
+        @test isa(pc, Dict)
     end
     """)
 


### PR DESCRIPTION
`@snoopi` is the simpler and more useful of the two macros, and since folks seem to like automation, we should support it.

Once merged I'll turn this into version 1.0.