### PR TITLE
Add support for Cthulhu

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompile"
 uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.6.2"
+version = "1.7.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -11,9 +11,9 @@ SnoopCompileBot = "1d5e0e55-7d74-4714-b8d8-efa80e938cf7"
 SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
 
 [compat]
-SnoopCompileAnalysis = "~1.6.2"
-SnoopCompileBot = "~1.6.2"
-SnoopCompileCore = "~1.6.2"
+SnoopCompileAnalysis = "~1.7.0"
+SnoopCompileBot = "~1.7.0"
+SnoopCompileCore = "~1.7.0"
 julia = "1"
 
 [extras]

--- a/SnoopCompileAnalysis/Project.toml
+++ b/SnoopCompileAnalysis/Project.toml
@@ -4,9 +4,11 @@ author = ["Tim Holy <tim.holy@gmail.com>"]
 version = "1.6.2"
 
 [deps]
+Cthulhu = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [compat]
+Cthulhu = "1.2"
 OrderedCollections = "1"
 julia = "1"

--- a/SnoopCompileAnalysis/Project.toml
+++ b/SnoopCompileAnalysis/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompileAnalysis"
 uuid = "9ea4277c-da97-4c3a-afb0-537c066769de"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.6.2"
+version = "1.7.0"
 
 [deps]
 Cthulhu = "f68482b8-f384-11e8-15f7-abe071a5a75f"

--- a/SnoopCompileAnalysis/src/invalidations.jl
+++ b/SnoopCompileAnalysis/src/invalidations.jl
@@ -1,4 +1,6 @@
-export invalidation_trees, filtermod, findcaller
+using Cthulhu
+
+export invalidation_trees, filtermod, findcaller, ascend
 
 # Variable names:
 # - `node`, `root`, `leaf`, `parent`, `child`: all `InstanceNode`s, a.k.a. nodes in a MethodInstance tree
@@ -411,3 +413,10 @@ function findcaller(meth::Method, node::InstanceNode)
     end
     return nothing
 end
+
+# Cthulhu integration
+
+Cthulhu.backedges(node::InstanceNode) = sort(node.children; by=countchildren, rev=true)
+Cthulhu.method(node::InstanceNode) = Cthulhu.method(node.mi)
+Cthulhu.specTypes(node::InstanceNode) = Cthulhu.specTypes(node.mi)
+Cthulhu.instance(node::InstanceNode) = node.mi

--- a/SnoopCompileAnalysis/src/invalidations.jl
+++ b/SnoopCompileAnalysis/src/invalidations.jl
@@ -168,19 +168,19 @@ function Base.show(io::IO, methinvs::MethodInvalidations)
             end
             printstyled(io, root.mi, color = :light_yellow)
             print(io, " (", countchildren(root), " children)")
-            if sig !== nothing
-                ms1, ms2 = method.sig <: sig, sig <: method.sig
-                diagnosis = if ms1 && !ms2
-                    "more specific"
-                elseif ms2 && !ms1
-                    "less specific"
-                elseif ms1 && ms1
-                    "equal specificity"
-                else
-                    "ambiguous"
-                end
-                printstyled(io, ' ', diagnosis, color=:red)
-            end
+            # if sig !== nothing
+            #     ms1, ms2 = method.sig <: sig, sig <: method.sig
+            #     diagnosis = if ms1 && !ms2
+            #         "more specific"
+            #     elseif ms2 && !ms1
+            #         "less specific"
+            #     elseif ms1 && ms1
+            #         "equal specificity"
+            #     else
+            #         "ambiguous"
+            #     end
+            #     printstyled(io, ' ', diagnosis, color=:red)
+            # end
             if iscompact
                 i < n && print(io, ", ")
             else

--- a/SnoopCompileAnalysis/src/invalidations.jl
+++ b/SnoopCompileAnalysis/src/invalidations.jl
@@ -1,6 +1,26 @@
 using Cthulhu
 
-export invalidation_trees, filtermod, findcaller, ascend
+export uinvalidated, invalidation_trees, filtermod, findcaller, ascend
+
+"""
+   umis = uinvalidated(invlist)
+
+Return the unique invalidated MethodInstances. `invlist` is obtained from [`SnoopCompileCore.@snoopr`](@ref).
+This is similar to `filter`ing for `MethodInstance`s in `invlist`, except that it discards any tagged
+`"invalidate_mt_cache"`. These can typically be ignored because they are nearly inconsequential:
+they do not invalidate any compiled code, they only transiently affect an optimization of runtime dispatch.
+"""
+function uinvalidated(invlist)
+    umis = Set{MethodInstance}()
+    for (i, item) in enumerate(invlist)
+        if isa(item, Core.MethodInstance)
+            if invlist[i+1] != "invalidate_mt_cache"
+                push!(umis, item)
+            end
+        end
+    end
+    return umis
+end
 
 # Variable names:
 # - `node`, `root`, `leaf`, `parent`, `child`: all `InstanceNode`s, a.k.a. nodes in a MethodInstance tree

--- a/SnoopCompileBot/Project.toml
+++ b/SnoopCompileBot/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompileBot"
 uuid = "1d5e0e55-7d74-4714-b8d8-efa80e938cf7"
 author = ["Amin Yahyaabadi <aminyahyaabadi74@gmail.com>"]
-version = "1.6.2"
+version = "1.7.0"
 
 [deps]
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
@@ -12,8 +12,8 @@ SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
 
 [compat]
 FilePathsBase = "0.9"
-SnoopCompileAnalysis = "~1.6.2"
-SnoopCompileCore = "~1.6.2"
+SnoopCompileAnalysis = "~1.7.0"
+SnoopCompileCore = "~1.7.0"
 YAML = "0.4"
 julia = "1"
 

--- a/SnoopCompileCore/Project.toml
+++ b/SnoopCompileCore/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompileCore"
 uuid = "e2b509da-e806-4183-be48-004708413034"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.6.2"
+version = "1.7.0"
 
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/docs/src/snoopr.md
+++ b/docs/src/snoopr.md
@@ -234,6 +234,8 @@ Choose a call for analysis (q to quit):
 ```
 
 This is an interactive menu: press the down arrow to go down, the up arrow to go up, and `Enter` to select an item for more detailed analysis.
+In large trees, you may also want to "fold" nodes of the tree (collapsing it so that the children are no longer displayed), particularly if you are working your way through a long series of invalidations and want to hide ones you've already dealt with. You toggle folding using the space bar, and folded nodes are printed with a `+` in front of them.
+
 For example, if we press the down arrow once, we get
 
 ```julia

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -14,7 +14,7 @@ if isdefined(SnoopCompileCore, Symbol("@snoopi"))
 end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopr"))
-    export @snoopr, invalidation_trees, filtermod, findcaller, ascend
+    export @snoopr, uinvalidated, invalidation_trees, filtermod, findcaller, ascend
     using SnoopCompileAnalysis: getroot, remove_if_not_eval!
 end
 

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -56,7 +56,7 @@ end
     str = String(take!(io))
     @test startswith(str, "inserting f(::AbstractFloat)")
     @test occursin("mt_backedges: 1: signature", str)
-    @test occursin("triggered MethodInstance for applyf(::Array{Any,1}) (1 children) more specific", str)
+    @test occursin("triggered MethodInstance for applyf(::Array{Any,1}) (1 children)", str)
 
     cf = Any[1.0f0]
     @test SnooprTests.callapplyf(cf) == 3
@@ -97,9 +97,9 @@ end
     str = String(take!(io))
     @test startswith(str, "inserting f(::Float32)")
     @test occursin("mt_backedges: 1: signature", str)
-    @test occursin("triggered MethodInstance for applyf(::Array{Any,1}) (1 children) more specific", str)
+    @test occursin("triggered MethodInstance for applyf(::Array{Any,1}) (1 children)", str)
     @test occursin("backedges: 1: superseding f(::AbstractFloat)", str)
-    @test occursin("with MethodInstance for f(::AbstractFloat) (1 children) more specific", str)
+    @test occursin("with MethodInstance for f(::AbstractFloat) (1 children)", str)
 
     show(io, root; minchildren=0)
     str = String(take!(io))

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -31,6 +31,8 @@ end
 
     invs = @snoopr SnooprTests.f(::AbstractFloat) = 3
     @test !isempty(invs)
+    umis = uinvalidated(invs)
+    @test !isempty(umis)
     trees = invalidation_trees(invs)
 
     methinvs = only(trees)

--- a/utils/dev.jl
+++ b/utils/dev.jl
@@ -1,0 +1,8 @@
+using Pkg
+rootdir = @__DIR__
+Pkg.develop([
+  PackageSpec(path=joinpath(rootdir,"SnoopCompileCore")),
+  PackageSpec(path=joinpath(rootdir,"SnoopCompileAnalysis")),
+  PackageSpec(path=joinpath(rootdir,"SnoopCompileBot")),
+  PackageSpec(path=rootdir),
+])

--- a/utils/register.jl
+++ b/utils/register.jl
@@ -1,0 +1,51 @@
+using LocalRegistry, Pkg
+
+const __topdir__ = dirname(@__DIR__)
+
+"""
+    bump_version(version::VersionNumber)
+
+Bump the version number of all packages in the repository to `version`.
+"""
+function bump_version(version::VersionNumber)
+    for dir in (__topdir__,
+                joinpath(__topdir__, "SnoopCompileAnalysis"),
+                joinpath(__topdir__, "SnoopCompileBot"),
+                joinpath(__topdir__, "SnoopCompileCore"))
+        projfile = joinpath(dir, "Project.toml")
+        lines = readlines(projfile)
+        idxs = findall(str->startswith(str, "version"), lines)
+        idx = only(idxs)
+        lines[idx] = "version = \"$version\""
+        # Find any dependencies on versions within the repo
+        idxs = findall(str->str == "[compat]", lines)
+        if !isempty(idxs)
+            idxcompat = only(idxs)
+            idxend = findnext(str->!isempty(str) && str[1] == '[', lines, idxcompat+1)  # first line of next TOML section
+            if idxend === nothing
+                idxend = length(lines) + 1
+            end
+            for i = idxcompat:idxend-1
+                if startswith(lines[i], "SnoopCompile")
+                    strs = split(lines[i], '=')
+                    lines[i] = strs[1] * "= \"~" * string(version) * '"'
+                end
+            end
+        end
+        open(projfile, "w") do io
+            for line in lines
+                println(io, line)
+            end
+        end
+    end
+    return nothing
+end
+
+function register_all()
+    for pkg in ("SnoopCompileCore", "SnoopCompileAnalysis", "SnoopCompileBot", "SnoopCompile")
+        Pkg.develop(pkg)
+        pkgsym = Symbol(pkg)
+        @eval Main using $pkgsym
+        register(getfield(Main, pkgsym)::Module)
+    end
+end


### PR DESCRIPTION
This is the final tool (so far) for fixing invalidations. `ascend` makes it much easier to identify a fruitful place to intervene and fix inference problems.

This also adds tools for bumping the versions across-the-board. What do you think of this, @aminya? Overall I think our best strategy is to keep all version numbers in lock-step, and that's the workflow made easy with these tools. When you want to bump the version, you say `bump_version(v"1.7.0")`. After the PR merges, update your local master branch to the latest, check out a branch of `registries/General`, and then `register_all()`. Then submit your `registries/General` as a PR.
