### PR TITLE
Fixing addtestdep not defined

### DIFF
--- a/SnoopCompileBot/src/botutils.jl
+++ b/SnoopCompileBot/src/botutils.jl
@@ -236,7 +236,7 @@ function pathof_noload(package_name::String)
 end
 
 ################################################################
-
+export addtestdep
 import Pkg
 """
 Should be removed once Pkg allows adding test dependencies to the current environment

--- a/docs/src/bot.md
+++ b/docs/src/bot.md
@@ -130,7 +130,7 @@ jobs:
       - name: Install dependencies
         run: |
           julia --project -e 'using Pkg; Pkg.instantiate();'
-          julia -e 'using Pkg; Pkg.add(PackageSpec(url = "https://github.com/timholy/SnoopCompile.jl")); Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompile; SnoopCompile.addtestdep();'
+          julia -e 'using Pkg; Pkg.add(PackageSpec(url = "https://github.com/timholy/SnoopCompile.jl")); Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompile; addtestdep();'
       - name: Generating precompile files
         run: julia --project -e 'include("deps/SnoopCompile/snoop_bot.jl")'   # NOTE: must match path
       - name: Running Benchmark

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -20,7 +20,7 @@ end
 
 using SnoopCompileBot
 export BotConfig, snoop_bot, snoop_bench
-export timesum, pathof_noload, GoodPath
+export timesum, pathof_noload, GoodPath, addtestdep
 if isdefined(SnoopCompileBot, Symbol("@snoopiBench"))
     # deprecated names
     export @snoopiBench, @snoopiBot, @snoopi_bench, @snoopi_bot


### PR DESCRIPTION
In this new configuration, people cannot call the internal functions of each package through SnoopCompile. 

We should probably use `@reexport` to solve this issue.