### PR TITLE
Version 1.6.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompile"
 uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -11,9 +11,9 @@ SnoopCompileBot = "1d5e0e55-7d74-4714-b8d8-efa80e938cf7"
 SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
 
 [compat]
-SnoopCompileAnalysis = "~1.6.1"
-SnoopCompileBot = "~1.6.1"
-SnoopCompileCore = "~1.6.1"
+SnoopCompileAnalysis = "~1.6.2"
+SnoopCompileBot = "~1.6.2"
+SnoopCompileCore = "~1.6.2"
 julia = "1"
 
 [extras]

--- a/SnoopCompileAnalysis/Project.toml
+++ b/SnoopCompileAnalysis/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompileAnalysis"
 uuid = "9ea4277c-da97-4c3a-afb0-537c066769de"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"

--- a/SnoopCompileBot/Project.toml
+++ b/SnoopCompileBot/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompileBot"
 uuid = "1d5e0e55-7d74-4714-b8d8-efa80e938cf7"
 author = ["Amin Yahyaabadi <aminyahyaabadi74@gmail.com>"]
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
@@ -12,8 +12,8 @@ SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
 
 [compat]
 FilePathsBase = "0.9"
-SnoopCompileAnalysis = "~1.6.1"
-SnoopCompileCore = "~1.6.1"
+SnoopCompileAnalysis = "~1.6.2"
+SnoopCompileCore = "~1.6.2"
 YAML = "0.4"
 julia = "1"
 

--- a/SnoopCompileBot/src/snoop_bench.jl
+++ b/SnoopCompileBot/src/snoop_bench.jl
@@ -4,7 +4,7 @@ function _snoopi_bench_cmd(snoop_script)
     return quote
         global SnoopCompile_ENV = true
 
-        using SnoopCompileCore
+        using SnoopCompile
 
         data = @snoopi tmin=$tmin begin
             $snoop_script
@@ -12,7 +12,7 @@ function _snoopi_bench_cmd(snoop_script)
 
         global SnoopCompile_ENV = false
 
-        using SnoopCompileBot: timesum
+        using SnoopCompile: timesum
         @info( "\nTotal inference time (ms): \t" * string(timesum(data, :ms)))
     end
 end
@@ -56,7 +56,7 @@ function _snoop_bench(config::BotConfig, snoop_script::Expr, test_modul::Module 
     out = quote
         package_sym = Symbol($package_name)
         ################################################################
-        using SnoopCompileBot
+        using SnoopCompile
         @info("""------------------------
         Benchmark Started
         ------------------------
@@ -66,7 +66,7 @@ function _snoop_bench(config::BotConfig, snoop_script::Expr, test_modul::Module 
         Precompile Deactivated Benchmark
         ------------------------
         """)
-        SnoopCompileBot.precompile_deactivator($package_path);
+        $precompile_deactivator($package_path);
         ### Log the compiles
         run($julia_cmd)
         ################################################################
@@ -74,7 +74,7 @@ function _snoop_bench(config::BotConfig, snoop_script::Expr, test_modul::Module 
         Precompile Activated Benchmark
         ------------------------
         """)
-        SnoopCompileBot.precompile_activator($package_path);
+        $precompile_activator($package_path);
         ### Log the compiles
         run($julia_cmd)
         @info("""------------------------

--- a/SnoopCompileBot/src/snoop_bot.jl
+++ b/SnoopCompileBot/src/snoop_bot.jl
@@ -1,7 +1,7 @@
 # Snooping functions
 function _snoopi_bot(snoop_script, tmin)
     return quote
-        using SnoopCompileCore
+        using SnoopCompile
 
         data = @snoopi tmin=$tmin begin
             $snoop_script
@@ -11,15 +11,13 @@ end
 
 function _snoopc_bot(snoop_script)
     return quote
-        using SnoopCompileCore
+        using SnoopCompile
 
         @snoopc "compiles.log" begin
             $snoop_script
         end
 
-        using SnoopCompileAnalysis
-
-        data = SnoopCompileAnalysis.read("compiles.log")[2]
+        data = SnoopCompile.read("compiles.log")[2]
         Base.rm("compiles.log", force = true)
     end
 end
@@ -31,15 +29,15 @@ function _snoop_analysis_bot(snooping_code, package_name, precompile_folder, sub
         ################################################################
         @info "Processsing the generated precompile signatures"
 
-        using SnoopCompileAnalysis
+        using SnoopCompile
 
         ### Parse the compiles and generate precompilation scripts
-        pc = SnoopCompileAnalysis.parcel(data; subst = $subst, exclusions = $exclusions, check_eval = $check_eval)
+        pc = SnoopCompile.parcel(data; subst = $subst, exclusions = $exclusions, check_eval = $check_eval)
         if !haskey(pc, packageSym)
             @error "no precompile signature is found for $($package_name). Don't load the package before snooping. Restart your Julia session."
         end
         onlypackage = Dict( packageSym => sort(pc[packageSym]) )
-        SnoopCompileAnalysis.write($precompile_folder, onlypackage)
+        SnoopCompile.write($precompile_folder, onlypackage)
         @info "precompile signatures were written to $($precompile_folder)"
     end
 end
@@ -78,7 +76,7 @@ function _snoop_bot_expr(config::BotConfig, snoop_script, test_modul::Module; sn
         if isnothing(version)
             precompile_folder = "$precompiles_rootpath/$(detectOS()[1])"
         else
-            precompile_folder = "$precompiles_rootpath/$( detectOS()[1])/$(VersionFloat(VERSION))"
+            precompile_folder = "$precompiles_rootpath/$(detectOS()[1])/$(VersionFloat(VERSION))"
         end
     end
 
@@ -109,20 +107,20 @@ function _snoop_bot_expr(config::BotConfig, snoop_script, test_modul::Module; sn
 
     out = quote
         ################################################################
-        using SnoopCompileBot
+        using SnoopCompile
 
         # Environment variable to detect SnoopCompile bot
         global SnoopCompile_ENV = true
 
         ################################################################
-        SnoopCompileBot.precompile_deactivator($package_path);
+        $precompile_deactivator($package_path);
         ################################################################
 
         ### Log the compiles and analyze the compiles
         run($julia_cmd)
 
         ################################################################
-        SnoopCompileBot.precompile_activator($package_path)
+        $precompile_activator($package_path)
 
         global SnoopCompile_ENV = false
     end

--- a/SnoopCompileBot/test/runtests.jl
+++ b/SnoopCompileBot/test/runtests.jl
@@ -1,4 +1,5 @@
-using SnoopCompileBot, Test
+using SnoopCompile, Test
+using SnoopCompile.SnoopCompileBot
 import SnoopCompileBot.goodjoinpath
 stripall(x::String) = replace(x, r"\s|\n"=>"")
 

--- a/SnoopCompileCore/Project.toml
+++ b/SnoopCompileCore/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompileCore"
 uuid = "e2b509da-e806-4183-be48-004708413034"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,4 +85,5 @@ if isdefined(SnoopCompile, :invalidation_trees)
 end
 
 # SnoopCompileBot tests:
-using Pkg; Pkg.test("SnoopCompileBot", coverage=true);
+# using Pkg; Pkg.test("SnoopCompileBot", coverage=true);
+include("../SnoopCompileBot/test/runtests.jl")


### PR DESCRIPTION
Fixes the bot on 1.6. Tested against MusicXML v0.3.2. I had to delete the `exhausive` keywords from the snoop scripts; that was never in a released version of SnoopCompile, so that isn't cheating.

@aminya, one thing I had to do to make it work was execute the instructions in https://github.com/timholy/SnoopCompile.jl/issues/105#issuecomment-649345931 in the MusicXML environment, since the bot launches with `--project`. Interestingly, I had to manually edit the paths in the resulting `MusicXML/Manifest.toml` manually: doing the `rm SnoopCompileCore ...` deleted the `path=` statement from the Manifest.toml and reverted to the git tree sha.