### PR TITLE
Using sub packages in SnoopCompileBot

### DIFF
--- a/.github/workflows/workflow_ci.yml
+++ b/.github/workflows/workflow_ci.yml
@@ -15,21 +15,15 @@ jobs:
         test_package:
           - ./SnoopCompileBot/test/TestPackage1.jl
     steps:
-      - run: |
-          if [ -z "${{github.head_ref}}" ]; then
-            echo ::set-env name=SnoopCompilePackageSpec::$(echo "PackageSpec(url = \"https://github.com/${{github.actor}}/SnoopCompile.jl\", rev = \"${GITHUB_REF#refs/heads/}\")")
-          else
-            echo ::set-env name=SnoopCompilePackageSpec::$(echo "PackageSpec(url = \"https://github.com/${{github.actor}}/SnoopCompile.jl\", rev = \"${{ github.head_ref }}\")")
-          fi
       - uses: actions/checkout@v2
-      - name: Add SnoopCompileBot
+      - name: Add SnoopCompileBot and friends
         run: |
-          julia -e 'using Pkg; Pkg.develop( PackageSpec(path="SnoopCompileBot") )'
+          julia -e 'using Pkg; Pkg.develop([PackageSpec(path="SnoopCompileCore"), PackageSpec(path="SnoopCompileAnalysis"), PackageSpec(path="SnoopCompileBot")]);'
       - name: Install dependencies
         working-directory: ${{ matrix.test_package }}
         run: |
           julia --project -e 'using Pkg; Pkg.instantiate();'
-          julia -e "using Pkg; Pkg.add($SnoopCompilePackageSpec); Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompile; SnoopCompile.addtestdep();"
+          julia -e "using Pkg; Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompileBot; SnoopCompileBot.addtestdep();"
       - name: Generating precompile files
         working-directory: ${{ matrix.test_package }}
         run: julia --project -e 'include("deps/SnoopCompile/snoop_bot.jl")'
@@ -49,28 +43,21 @@ jobs:
         test_package:
           - ./SnoopCompileBot/test/TestPackage2.jl
     steps:
-      - run: |
-          if [ -z "${{github.head_ref}}" ]; then
-            echo ::set-env name=SnoopCompilePackageSpec::$(echo "PackageSpec(url = \"https://github.com/${{github.actor}}/SnoopCompile.jl\", rev = \"${GITHUB_REF#refs/heads/}\")")
-          else
-            echo ::set-env name=SnoopCompilePackageSpec::$(echo "PackageSpec(url = \"https://github.com/${{github.actor}}/SnoopCompile.jl\", rev = \"${{ github.head_ref }}\")")
-          fi
       - uses: actions/checkout@v2
-      - name: Add SnoopCompileBot
+      - name: Add SnoopCompileBot and friends
         run: |
-          julia -e 'using Pkg; Pkg.develop( PackageSpec(path="SnoopCompileBot") )'
+          julia -e 'using Pkg; Pkg.develop([PackageSpec(path="SnoopCompileCore"), PackageSpec(path="SnoopCompileAnalysis"), PackageSpec(path="SnoopCompileBot")]);'
       - name: Install dependencies
         working-directory: ${{ matrix.test_package }}
         run: |
           julia --project -e 'using Pkg; Pkg.instantiate();'
-          julia -e "using Pkg; Pkg.add($SnoopCompilePackageSpec); Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompile; SnoopCompile.addtestdep();"
+          julia -e "using Pkg; Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompileBot; SnoopCompileBot.addtestdep();"
       - name: Generating precompile files
         working-directory: ${{ matrix.test_package }}
         run: julia --project -e 'include("deps/SnoopCompile/snoop_bot.jl")'
       - name: Running Benchmark
         working-directory: ${{ matrix.test_package }}
         run: julia --project -e 'include("deps/SnoopCompile/snoop_bench.jl")'
-
 
   MultiVersion:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
@@ -85,24 +72,18 @@ jobs:
         test_package:
           - ./SnoopCompileBot/test/TestPackage3.jl
     steps:
-      - run: |
-          if [ -z "${{github.head_ref}}" ]; then
-            echo ::set-env name=SnoopCompilePackageSpec::$(echo "PackageSpec(url = \"https://github.com/${{github.actor}}/SnoopCompile.jl\", rev = \"${GITHUB_REF#refs/heads/}\")")
-          else
-            echo ::set-env name=SnoopCompilePackageSpec::$(echo "PackageSpec(url = \"https://github.com/${{github.actor}}/SnoopCompile.jl\", rev = \"${{ github.head_ref }}\")")
-          fi
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
-      - name: Add SnoopCompileBot
+      - name: Add SnoopCompileBot and friends
         run: |
-          julia -e 'using Pkg; Pkg.develop( PackageSpec(path="SnoopCompileBot") )'
+          julia -e 'using Pkg; Pkg.develop([PackageSpec(path="SnoopCompileCore"), PackageSpec(path="SnoopCompileAnalysis"), PackageSpec(path="SnoopCompileBot")]);'
       - name: Install dependencies
         working-directory: ${{ matrix.test_package }}
         run: |
           julia --project -e 'using Pkg; Pkg.instantiate();'
-          julia -e "using Pkg; Pkg.add($SnoopCompilePackageSpec); Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompile; SnoopCompile.addtestdep();"
+          julia -e "using Pkg; Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompileBot; SnoopCompileBot.addtestdep();"
       - name: Generating precompile files
         working-directory: ${{ matrix.test_package }}
         run: julia --project -e 'include("deps/SnoopCompile/snoop_bot.jl")'

--- a/SnoopCompileBot/src/snoop_bench.jl
+++ b/SnoopCompileBot/src/snoop_bench.jl
@@ -3,8 +3,7 @@ function _snoopi_bench_cmd(snoop_script)
     tmin = 0.0 # For benchmarking
     return quote
         global SnoopCompile_ENV = true
-
-        using SnoopCompile
+        using SnoopCompileCore
 
         data = @snoopi tmin=$tmin begin
             $snoop_script
@@ -12,7 +11,7 @@ function _snoopi_bench_cmd(snoop_script)
 
         global SnoopCompile_ENV = false
 
-        using SnoopCompile: timesum
+        using SnoopCompileBot: timesum
         @info( "\nTotal inference time (ms): \t" * string(timesum(data, :ms)))
     end
 end
@@ -56,7 +55,8 @@ function _snoop_bench(config::BotConfig, snoop_script::Expr, test_modul::Module 
     out = quote
         package_sym = Symbol($package_name)
         ################################################################
-        using SnoopCompile
+        using SnoopCompileBot
+
         @info("""------------------------
         Benchmark Started
         ------------------------
@@ -66,7 +66,7 @@ function _snoop_bench(config::BotConfig, snoop_script::Expr, test_modul::Module 
         Precompile Deactivated Benchmark
         ------------------------
         """)
-        $precompile_deactivator($package_path);
+        SnoopCompileBot.precompile_deactivator($package_path);
         ### Log the compiles
         run($julia_cmd)
         ################################################################
@@ -74,7 +74,7 @@ function _snoop_bench(config::BotConfig, snoop_script::Expr, test_modul::Module 
         Precompile Activated Benchmark
         ------------------------
         """)
-        $precompile_activator($package_path);
+        SnoopCompileBot.precompile_activator($package_path);
         ### Log the compiles
         run($julia_cmd)
         @info("""------------------------

--- a/SnoopCompileBot/src/snoop_bench.jl
+++ b/SnoopCompileBot/src/snoop_bench.jl
@@ -52,6 +52,8 @@ function _snoop_bench(config::BotConfig, snoop_script::Expr, test_modul::Module 
     ################################################################
     julia_cmd = `julia --project=@. -e $snooping_code`
 
+    addpkg_ifnotfound(:SnoopCompileCore, test_modul)
+    devpkg_ifnotfound(:SnoopCopmileBot, "$(dirname(@__DIR__))", test_modul)
     out = quote
         package_sym = Symbol($package_name)
         ################################################################

--- a/SnoopCompileBot/src/snoop_bot.jl
+++ b/SnoopCompileBot/src/snoop_bot.jl
@@ -107,6 +107,9 @@ function _snoop_bot_expr(config::BotConfig, snoop_script, test_modul::Module; sn
 
     julia_cmd = `julia --project=@. -e $snooping_analysis_code`
 
+    addpkg_ifnotfound(:SnoopCompileCore, test_modul)
+    addpkg_ifnotfound(:SnoopCompileAnalysis, test_modul)
+    devpkg_ifnotfound(:SnoopCopmileBot, "$(dirname(@__DIR__))", test_modul)
     out = quote
         ################################################################
         using SnoopCompileBot

--- a/SnoopCompileBot/src/snoop_bot.jl
+++ b/SnoopCompileBot/src/snoop_bot.jl
@@ -1,7 +1,7 @@
 # Snooping functions
 function _snoopi_bot(snoop_script, tmin)
     return quote
-        using SnoopCompile
+        using SnoopCompileCore
 
         data = @snoopi tmin=$tmin begin
             $snoop_script
@@ -11,13 +11,15 @@ end
 
 function _snoopc_bot(snoop_script)
     return quote
-        using SnoopCompile
+        using SnoopCompileCore
 
         @snoopc "compiles.log" begin
             $snoop_script
         end
 
-        data = SnoopCompile.read("compiles.log")[2]
+        using SnoopCompileAnalysis
+
+        data = SnoopCompileAnalysis.read("compiles.log")[2]
         Base.rm("compiles.log", force = true)
     end
 end
@@ -29,15 +31,15 @@ function _snoop_analysis_bot(snooping_code, package_name, precompile_folder, sub
         ################################################################
         @info "Processsing the generated precompile signatures"
 
-        using SnoopCompile
+        using SnoopCompileAnalysis
 
         ### Parse the compiles and generate precompilation scripts
-        pc = SnoopCompile.parcel(data; subst = $subst, exclusions = $exclusions, check_eval = $check_eval)
+        pc = SnoopCompileAnalysis.parcel(data; subst = $subst, exclusions = $exclusions, check_eval = $check_eval)
         if !haskey(pc, packageSym)
             @error "no precompile signature is found for $($package_name). Don't load the package before snooping. Restart your Julia session."
         end
         onlypackage = Dict( packageSym => sort(pc[packageSym]) )
-        SnoopCompile.write($precompile_folder, onlypackage)
+        SnoopCompileAnalysis.write($precompile_folder, onlypackage)
         @info "precompile signatures were written to $($precompile_folder)"
     end
 end
@@ -107,20 +109,20 @@ function _snoop_bot_expr(config::BotConfig, snoop_script, test_modul::Module; sn
 
     out = quote
         ################################################################
-        using SnoopCompile
+        using SnoopCompileBot
 
         # Environment variable to detect SnoopCompile bot
         global SnoopCompile_ENV = true
 
         ################################################################
-        $precompile_deactivator($package_path);
+        SnoopCompileBot.precompile_deactivator($package_path);
         ################################################################
 
         ### Log the compiles and analyze the compiles
         run($julia_cmd)
 
         ################################################################
-        $precompile_activator($package_path)
+        SnoopCompileBot.precompile_activator($package_path)
 
         global SnoopCompile_ENV = false
     end

--- a/SnoopCompileBot/test/runtests.jl
+++ b/SnoopCompileBot/test/runtests.jl
@@ -1,5 +1,4 @@
-using SnoopCompile, Test
-using SnoopCompile.SnoopCompileBot
+using SnoopCompileBot, Test
 import SnoopCompileBot.goodjoinpath
 stripall(x::String) = replace(x, r"\s|\n"=>"")
 

--- a/docs/src/bot.md
+++ b/docs/src/bot.md
@@ -130,7 +130,7 @@ jobs:
       - name: Install dependencies
         run: |
           julia --project -e 'using Pkg; Pkg.instantiate();'
-          julia -e 'using Pkg; Pkg.add(PackageSpec(url = "https://github.com/timholy/SnoopCompile.jl")); Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompile; SnoopCompile.addtestdep();'
+          julia -e 'using Pkg; Pkg.add(["SnoopCompileCore", "SnoopCompileAnalysis", "SnoopCompileBot"]); Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompileBot; SnoopCompileBot.addtestdep();'
       - name: Generating precompile files
         run: julia --project -e 'include("deps/SnoopCompile/snoop_bot.jl")'   # NOTE: must match path
       - name: Running Benchmark

--- a/docs/src/bot.md
+++ b/docs/src/bot.md
@@ -113,10 +113,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:   # NOTE: the versions below should match those in your botconfig
+        version:   # NOTE: if not using `yml_path`, the versions below should match those in your botconfig
           - '1.4.2'
           - '1.3.1'
-        os:        # NOTE: should match the os setting of your botconfig
+        os:        # NOTE: if not using `yml_path`, should match the os setting of your botconfig
           - ubuntu-latest
           - windows-latest
           - macos-latest


### PR DESCRIPTION
Together with my next pull request which will add snoopr to SnoopCompileBot, this will should be tagged as 1.8

As you see, [despite adding the packages in advance](https://github.com/aminya/SnoopCompile.jl/blob/BotSubPackage/.github/workflows/workflow_ci.yml#L49), the sub-packages are not found in the `test_modul` and my compatibility function is triggered to fix that.
https://github.com/timholy/SnoopCompile.jl/pull/118/checks?check_run_id=825156566#step:5:6