### PR TITLE
Make the version check more flexible

### DIFF
--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -24,7 +24,7 @@ if VERSION >= v"1.2.0-DEV.573"
     include("parcel_snoopi.jl")
 end
 
-if VERSION >= v"1.6.0-DEV.154"
+if isdefined(SnoopCompileCore, Symbol("@snoopr"))
     include("invalidations.jl")
 end
 


### PR DESCRIPTION
This centralizes all snoopr decision-making. If one goes to the trouble to backport the necessary infrastructure to older Julia versions, this makes it easier to load the functionality.