### PR TITLE
Add snoopl() to snoop time in LLVM optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         version:
           - '1.0'

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ author = ["Tim Holy <tim.holy@gmail.com>"]
 version = "2.1.1"
 
 [deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Cthulhu = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Cthulhu = "1.2"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ author = ["Tim Holy <tim.holy@gmail.com>"]
 version = "2.1.2"
 
 [deps]
-CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Cthulhu = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -14,10 +13,9 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Cthulhu = "1.2"
-CSV = "0.7"
 OrderedCollections = "1"
-YAML = "0.4"
 SnoopCompileCore = "~2.1.2"
+YAML = "0.4"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,9 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Cthulhu = "1.2"
+CSV = "0.7"
 OrderedCollections = "1"
+YAML = "0.4"
 SnoopCompileCore = "~2.1.2"
 julia = "1"
 

--- a/SnoopCompileCore/src/SnoopCompileCore.jl
+++ b/SnoopCompileCore/src/SnoopCompileCore.jl
@@ -16,4 +16,8 @@ if VERSION >= v"1.6.0-DEV.154"
     include("snoopr.jl")
 end
 
+if VERSION >= v"1.6.0-DEV.548"  # TODO(NHD)
+    include("snoopl.jl")
+end
+
 end

--- a/SnoopCompileCore/src/SnoopCompileCore.jl
+++ b/SnoopCompileCore/src/SnoopCompileCore.jl
@@ -16,8 +16,8 @@ if VERSION >= v"1.6.0-DEV.154"
     include("snoopr.jl")
 end
 
-#if VERSION >= v"1.6.0-DEV.548"  # TODO(NHD)
+if VERSION >= v"1.6.0-DEV.1192"  # https://github.com/JuliaLang/julia/pull/37136
     include("snoopl.jl")
-#end
+end
 
 end

--- a/SnoopCompileCore/src/SnoopCompileCore.jl
+++ b/SnoopCompileCore/src/SnoopCompileCore.jl
@@ -16,8 +16,8 @@ if VERSION >= v"1.6.0-DEV.154"
     include("snoopr.jl")
 end
 
-if VERSION >= v"1.6.0-DEV.548"  # TODO(NHD)
+#if VERSION >= v"1.6.0-DEV.548"  # TODO(NHD)
     include("snoopl.jl")
-end
+#end
 
 end

--- a/SnoopCompileCore/src/snoopl.jl
+++ b/SnoopCompileCore/src/snoopl.jl
@@ -1,0 +1,51 @@
+export @snoopl
+
+using Serialization
+
+"""
+```
+@snoopl "func_info.csv" "llvm_timings.csv" begin
+    # Commands to execute, in a new process
+end
+```
+causes the julia compiler to emit the LLVM optimization times for
+of executing the commands to the file "compiledata.csv". This file
+can be used for the input to `snooplompile.read`.
+"""
+macro snoopl(flags, func_file, llvm_file, commands)
+    return :(snoopl($(esc(flags)), $(esc(func_file)), $(esc(llvm_file)), $(QuoteNode(commands))))
+end
+macro snoopl(func_file, llvm_file, commands)
+    return :(snoopl(String[], $(esc(func_file)), $(esc(llvm_file)), $(QuoteNode(commands))))
+end
+
+function snoopl(flags, func_file, llvm_file, commands)
+    println("Launching new julia process to run commands...")
+    # addprocs will run the unmodified version of julia, so we
+    # launch it as a command.
+    code_object = """
+            using Serialization
+            while !eof(stdin)
+                Core.eval(Main, deserialize(stdin))
+            end
+            """
+    process = open(`$(Base.julia_cmd()) $flags --eval $code_object`, stdout, write=true)
+    serialize(process, quote
+        let func_io = open($func_file, "w"), llvm_io = open($llvm_file, "w")
+            ccall(:jl_dump_emitted_mi_name, Nothing, (Ptr{Nothing},), func_io.handle)
+            ccall(:jl_dump_llvm_opt, Nothing, (Ptr{Nothing},), llvm_io.handle)
+            try
+                $commands
+            finally
+                ccall(:jl_dump_emitted_mi_name, Nothing, (Ptr{Nothing},), C_NULL)
+                ccall(:jl_dump_llvm_opt, Nothing, (Ptr{Nothing},), C_NULL)
+                close(func_io)
+                close(llvm_io)
+            end
+        end
+        exit()
+    end)
+    wait(process)
+    println("done.")
+    nothing
+end

--- a/SnoopCompileCore/src/snoopl.jl
+++ b/SnoopCompileCore/src/snoopl.jl
@@ -10,7 +10,7 @@ end
 ```
 causes the julia compiler to emit the LLVM optimization times for
 of executing the commands to the files "func_names.csv" and "llvm_timings.yaml". These files
-can be used for the input to <TODO>.
+can be used for the input to `SnoopCompile.read_snoopl("func_names.csv", "llvm_timings.yaml")`
 """
 macro snoopl(flags, func_file, llvm_file, commands)
     return :(snoopl($(esc(flags)), $(esc(func_file)), $(esc(llvm_file)), $(QuoteNode(commands))))

--- a/SnoopCompileCore/src/snoopl.jl
+++ b/SnoopCompileCore/src/snoopl.jl
@@ -4,13 +4,13 @@ using Serialization
 
 """
 ```
-@snoopl "func_info.csv" "llvm_timings.csv" begin
+@snoopl "func_names.csv" "llvm_timings.yaml" begin
     # Commands to execute, in a new process
 end
 ```
 causes the julia compiler to emit the LLVM optimization times for
-of executing the commands to the file "compiledata.csv". This file
-can be used for the input to `snooplompile.read`.
+of executing the commands to the files "func_names.csv" and "llvm_timings.yaml". These files
+can be used for the input to <TODO>.
 """
 macro snoopl(flags, func_file, llvm_file, commands)
     return :(snoopl($(esc(flags)), $(esc(func_file)), $(esc(llvm_file)), $(QuoteNode(commands))))

--- a/SnoopCompileCore/src/snoopl.jl
+++ b/SnoopCompileCore/src/snoopl.jl
@@ -8,9 +8,12 @@ using Serialization
     # Commands to execute, in a new process
 end
 ```
-causes the julia compiler to emit the LLVM optimization times for
-of executing the commands to the files "func_names.csv" and "llvm_timings.yaml". These files
-can be used for the input to `SnoopCompile.read_snoopl("func_names.csv", "llvm_timings.yaml")`
+causes the julia compiler to log timing information for LLVM optimization during the
+provided commands to the files "func_names.csv" and "llvm_timings.yaml". These files can
+be used for the input to `SnoopCompile.read_snoopl("func_names.csv", "llvm_timings.yaml")`.
+
+The logs contain the amount of time spent optimizing each "llvm module", and information
+about each module, where a module is a collection of functions being optimized together.
 """
 macro snoopl(flags, func_file, llvm_file, commands)
     return :(snoopl($(esc(flags)), $(esc(func_file)), $(esc(llvm_file)), $(QuoteNode(commands))))

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -6,10 +6,13 @@ isdefined(SnoopCompileCore, Symbol("@snoopi")) && export @snoopi
 if isdefined(SnoopCompileCore, Symbol("@snoopr"))
     export @snoopr, uinvalidated, invalidation_trees, filtermod, findcaller, ascend
 end
+if isdefined(SnoopCompileCore, Symbol("@snoopl"))
+    export @snoopl, read_snoopl
+end
 
 using Core: MethodInstance, CodeInfo
 using Serialization, OrderedCollections
-import YAML,CSV  # For @snoopl
+import YAML  # For @snoopl
 
 # Parcel Regex
 const anonrex = r"#{1,2}\d+#{1,2}\d+"         # detect anonymous functions

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -25,12 +25,7 @@ if VERSION >= v"1.2.0-DEV.573"
     include("parcel_snoopi.jl")
 end
 
-# TODO(PR): It seems reasonable to me to leave this alaways available, since even if you're
-# using a version of julia that doesn't support `@snoopl`, it seems like it's still nice to
-# let you _read and reason about_ the results of a snoopl run?
-#if VERSION >= v"1.6.0-DEV.1192"  # https://github.com/JuliaLang/julia/pull/37136
-    include("parcel_snoopl.jl")
-#end
+include("parcel_snoopl.jl")
 
 if isdefined(SnoopCompileCore, Symbol("@snoopr"))
     include("invalidations.jl")

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -25,9 +25,12 @@ if VERSION >= v"1.2.0-DEV.573"
     include("parcel_snoopi.jl")
 end
 
-if VERSION >= v"1.6.0-DEV.1192"  # https://github.com/JuliaLang/julia/pull/37136
+# TODO(PR): It seems reasonable to me to leave this alaways available, since even if you're
+# using a version of julia that doesn't support `@snoopl`, it seems like it's still nice to
+# let you _read and reason about_ the results of a snoopl run?
+#if VERSION >= v"1.6.0-DEV.1192"  # https://github.com/JuliaLang/julia/pull/37136
     include("parcel_snoopl.jl")
-end
+#end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopr"))
     include("invalidations.jl")

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -25,10 +25,9 @@ if VERSION >= v"1.2.0-DEV.573"
     include("parcel_snoopi.jl")
 end
 
-# TODO: version bounds
-#if VERSION >= v"1.2.0-DEV.573"
+if VERSION >= v"1.6.0-DEV.1192"  # https://github.com/JuliaLang/julia/pull/37136
     include("parcel_snoopl.jl")
-#end
+end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopr"))
     include("invalidations.jl")

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -9,6 +9,7 @@ end
 
 using Core: MethodInstance, CodeInfo
 using Serialization, OrderedCollections
+import YAML,CSV  # For @snoopl
 
 # Parcel Regex
 const anonrex = r"#{1,2}\d+#{1,2}\d+"         # detect anonymous functions
@@ -23,6 +24,11 @@ include("parcel_snoopc.jl")
 if VERSION >= v"1.2.0-DEV.573"
     include("parcel_snoopi.jl")
 end
+
+# TODO: version bounds
+#if VERSION >= v"1.2.0-DEV.573"
+    include("parcel_snoopl.jl")
+#end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopr"))
     include("invalidations.jl")

--- a/src/parcel_snoopl.jl
+++ b/src/parcel_snoopl.jl
@@ -4,7 +4,7 @@
 Reads the log file produced by the compiler and returns the structured representations.
 """
 function read_snoopl(func_csv_file, llvm_yaml_file)
-    func_csv = CSV.File(func_csv_file, header=false)
+    func_csv = CSV.File(func_csv_file, header=false, delim='\t', types=[String, String])
     llvm_yaml = YAML.load_file(llvm_yaml_file)
 
     jl_names = Dict(r[1] => r[2] for r in func_csv)
@@ -38,6 +38,6 @@ function read_snoopl(func_csv_file, llvm_yaml_file)
     )
 
 
-    # Save the most costly for last
+    # sort times so that the most costly items are displayed last
     return (sort(times), info)
 end

--- a/src/parcel_snoopl.jl
+++ b/src/parcel_snoopl.jl
@@ -7,7 +7,7 @@ function read_snoopl(func_csv_file, llvm_yaml_file; tmin_secs=0.0)
     func_csv = CSV.File(func_csv_file, header=false, delim='\t', types=[String, String])
     llvm_yaml = YAML.load_file(llvm_yaml_file)
 
-    jl_names = Dict(r[1] => r[2] for r in func_csv)
+    jl_names = Dict(r[1]::String => r[2]::String for r in func_csv)
 
     try_get_jl_name(name) = if name in keys(jl_names)
         jl_names[name]

--- a/src/parcel_snoopl.jl
+++ b/src/parcel_snoopl.jl
@@ -4,7 +4,7 @@
 Reads the log file produced by the compiler and returns the structured representations.
 """
 function read_snoopl(func_csv_file, llvm_yaml_file; tmin_secs=0.0)
-    func_csv = CSV.File(func_csv_file, header=false, delim='\t', types=[String, String])
+    func_csv = _read_snoopl_csv(func_csv_file)
     llvm_yaml = YAML.load_file(llvm_yaml_file)
 
     jl_names = Dict(r[1]::String => r[2]::String for r in func_csv)
@@ -46,4 +46,21 @@ function read_snoopl(func_csv_file, llvm_yaml_file; tmin_secs=0.0)
 
     # sort times so that the most costly items are displayed last
     return (sort(times), info)
+end
+
+
+"""
+`SnoopCompile._read_snoopl_csv("compiledata.csv")` reads the log file produced by the
+compiler and returns the function names as an array of pairs.
+"""
+function _read_snoopl_csv(filename)
+    data = Vector{Pair{String,String}}()
+    # Format is [^\t]+\t[^\t]+. That is, tab-separated entries. No quotations or other
+    # whitespace are considered.
+    for line in eachline(filename)
+        c_name, jl_type = split2(line, '\t')
+        (length(c_name) < 2 || length(jl_type) < 2) && continue
+        push!(data, c_name => jl_type)
+    end
+    return data
 end

--- a/src/parcel_snoopl.jl
+++ b/src/parcel_snoopl.jl
@@ -1,0 +1,43 @@
+"""
+    times, info = SnoopCompile.read_snoopl("func_names.csv", "llvm_timings.yaml")
+
+Reads the log file produced by the compiler and returns the structured representations.
+"""
+function read_snoopl(func_csv_file, llvm_yaml_file)
+    func_csv = CSV.File(func_csv_file, header=false)
+    llvm_yaml = YAML.load_file(llvm_yaml_file)
+
+    jl_names = Dict(r[1] => r[2] for r in func_csv)
+
+    try_get_jl_name(name) = if name in keys(jl_names)
+        jl_names[name]
+        else
+            @warn "Couldn't find $name"
+            name
+        end
+
+    times = [llvm_module["time_ns"] => [
+        try_get_jl_name(name)
+        for (name,_) in llvm_module["before"]
+    ] for llvm_module in llvm_yaml]
+
+    info = Dict(
+        try_get_jl_name(name) => (;
+            before = (;
+                instructions = before_stats["instructions"],
+                basicblocks = before_stats["basicblocks"],
+            ),
+            after = (;
+                instructions = after_stats["instructions"],
+                basicblocks = after_stats["basicblocks"],
+            ),
+        )
+        for llvm_module in llvm_yaml
+        for (name, before_stats) in llvm_module["before"]
+        for (name, after_stats)  in llvm_module["after"]
+    )
+
+
+    # Save the most costly for last
+    return (sort(times), info)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,18 @@
+using Test
+
 if VERSION >= v"1.2.0-DEV.573"
     include("snoopi.jl")
+end
+
+if VERSION >= v"1.6.0-DEV.1192"  # https://github.com/JuliaLang/julia/pull/37136
+    @testset "snoopl" begin
+        include("snoopl.jl")
+    end
 end
 
 using SnoopCompile
 using JLD
 using SparseArrays
-using Test
 
 # issue #26
 logfile = joinpath(tempdir(), "anon.log")

--- a/test/snoopl.jl
+++ b/test/snoopl.jl
@@ -1,0 +1,22 @@
+using Test
+
+using SnoopCompile
+using SnoopCompile.SnoopCompileCore
+
+@testset "@snoopl" begin
+
+    @snoopl "func_names.csv" "llvm_timings.yaml" begin
+        @eval module M
+            i(x) = x+5
+            h(a::Array) = i(a[1]::Integer) + 2
+            g(y::Integer) = h(Any[y])
+        end;
+        @eval M.g(3)
+    end;
+
+    times, info = SnoopCompile.read_snoopl("func_names.csv", "llvm_timings.yaml")
+
+    @test length(times) == 3  # i(), h(), g()
+    @test length(info) == 3  # i(), h(), g()
+
+end

--- a/test/snoopl.jl
+++ b/test/snoopl.jl
@@ -1,7 +1,6 @@
 using Test
 
 using SnoopCompile
-using SnoopCompile.SnoopCompileCore
 
 @testset "@snoopl" begin
 


### PR DESCRIPTION
This uses the associated code added in https://github.com/JuliaLang/julia/pull/37136 to get its timings.

Adds a macro to SnoopCompileCore, `@snoopl`, which collects timings for the LLVM optimization of compilation, and adds functions to display and understand the resulting timings.

Co-Authored-By: @Sacha0 @vchuravy 