### PR TITLE
Use changes to Julia to have `@snoopi` report _all MethodInstances_ that are inferred during a single inference call

### DIFF
--- a/SnoopCompileCore/src/snoopi.jl
+++ b/SnoopCompileCore/src/snoopi.jl
@@ -24,7 +24,7 @@ if isdefined(Core.Compiler, :Params)
     end
     @noinline function stop_timing()
         ccall(:jl_set_typeinf_func, Cvoid, (Any,), Core.Compiler.typeinf_ext)
-        #Core.Compiler.__collect_inference_callees__[] = false
+        Core.Compiler.__collect_inference_callees__[] = false
     end
 else
     function typeinf_ext_timed(interp::Core.Compiler.AbstractInterpreter, linfo::Core.MethodInstance)
@@ -47,13 +47,13 @@ else
     end
     @noinline function stop_timing()
         ccall(:jl_set_typeinf_func, Cvoid, (Any,), Core.Compiler.typeinf_ext_toplevel)
-        #Core.Compiler.__collect_inference_callees__[] = false
+        Core.Compiler.__collect_inference_callees__[] = false
     end
 end
 
 @noinline function start_timing()
     ccall(:jl_set_typeinf_func, Cvoid, (Any,), typeinf_ext_timed)
-    #Core.Compiler.__collect_inference_callees__[] = true
+    Core.Compiler.__collect_inference_callees__[] = true
 end
 
 function sort_timed_inf(tmin)

--- a/SnoopCompileCore/src/snoopi.jl
+++ b/SnoopCompileCore/src/snoopi.jl
@@ -1,20 +1,20 @@
 export @snoopi
 
 const __inf_timing__ = Tuple{Float64,MethodInstance}[]
-const __inf_callees__ = Dict{MethodInstance, Vector{MethodInstance}}()
+#const __inf_callees__ = Dict{MethodInstance, Vector{MethodInstance}}()
 const __inf_callee_edges4__ = Dict{MethodInstance, Vector{Any}}()
 
 if isdefined(Core.Compiler, :Params)
     function typeinf_ext_timed(linfo::Core.MethodInstance, params::Core.Compiler.Params)
         #Core.println("starting $linfo")
-        empty!(Core.Compiler.__inference_callees__)
+        #empty!(Core.Compiler.__inference_callees__)
         #empty!(Core.Compiler.__inference_callee_edges4__)
         push!(Core.Compiler.__inference_callee_edges4__, (linfo, Tuple{MethodInstance,MethodInstance}[]))
         tstart = time()
         ret = Core.Compiler.typeinf_ext(linfo, params)
         tstop = time()
         push!(__inf_timing__, (tstop-tstart, linfo))
-        __inf_callees__[linfo] = Core.Compiler.__inference_callees__
+        #__inf_callees__[linfo] = Core.Compiler.__inference_callees__
         @assert Core.Compiler.__inference_callee_edges4__[end][1] == linfo
         __inf_callee_edges4__[linfo] = pop!(Core.Compiler.__inference_callee_edges4__)[2]
         #Core.println("push: ", Core.Compiler.__inference_callee_edges4__)
@@ -22,13 +22,13 @@ if isdefined(Core.Compiler, :Params)
     end
     function typeinf_ext_timed(linfo::Core.MethodInstance, world::UInt)
         #Core.println("starting $linfo")
-        empty!(Core.Compiler.__inference_callees__)
+        #empty!(Core.Compiler.__inference_callees__)
         push!(Core.Compiler.__inference_callee_edges4__, (linfo, Tuple{MethodInstance,MethodInstance}[]))
         tstart = time()
         ret = Core.Compiler.typeinf_ext(linfo, world)
         tstop = time()
         push!(__inf_timing__, (tstop-tstart, linfo))
-        __inf_callees__[linfo] = Core.Compiler.__inference_callees__
+        #__inf_callees__[linfo] = Core.Compiler.__inference_callees__
         @assert Core.Compiler.__inference_callee_edges4__[end][1] == linfo
         __inf_callee_edges4__[linfo] = pop!(Core.Compiler.__inference_callee_edges4__)[2]
         #Core.println("push: ", Core.Compiler.__inference_callee_edges4__)
@@ -41,13 +41,13 @@ if isdefined(Core.Compiler, :Params)
 else
     function typeinf_ext_timed(interp::Core.Compiler.AbstractInterpreter, linfo::Core.MethodInstance)
         #Core.println("starting $linfo")
-        empty!(Core.Compiler.__inference_callees__)
+        #empty!(Core.Compiler.__inference_callees__)
         push!(Core.Compiler.__inference_callee_edges4__, (linfo, Tuple{MethodInstance,MethodInstance}[]))
         tstart = time()
         ret = Core.Compiler.typeinf_ext_toplevel(interp, linfo)
         tstop = time()
         push!(__inf_timing__, (tstop-tstart, linfo))
-        __inf_callees__[linfo] = Core.Compiler.__inference_callees__
+        #__inf_callees__[linfo] = Core.Compiler.__inference_callees__
         @assert Core.Compiler.__inference_callee_edges4__[end][1] == linfo
         __inf_callee_edges4__[linfo] = pop!(Core.Compiler.__inference_callee_edges4__)[2]
         #Core.println("push: ", Core.Compiler.__inference_callee_edges4__)
@@ -55,13 +55,13 @@ else
     end
     function typeinf_ext_timed(linfo::Core.MethodInstance, world::UInt)
         #Core.println("starting $linfo")
-        empty!(Core.Compiler.__inference_callees__)
+        #empty!(Core.Compiler.__inference_callees__)
         push!(Core.Compiler.__inference_callee_edges4__, (linfo, Tuple{MethodInstance,MethodInstance}[]))
         tstart = time()
         ret = Core.Compiler.typeinf_ext_toplevel(linfo, world)
         tstop = time()
         push!(__inf_timing__, (tstop-tstart, linfo))
-        __inf_callees__[linfo] = Core.Compiler.__inference_callees__
+        #__inf_callees__[linfo] = Core.Compiler.__inference_callees__
         @assert Core.Compiler.__inference_callee_edges4__[end][1] == linfo
         __inf_callee_edges4__[linfo] = pop!(Core.Compiler.__inference_callee_edges4__)[2]
         #Core.println("push: ", Core.Compiler.__inference_callee_edges4__)
@@ -128,7 +128,7 @@ end
 function _snoopi(cmd::Expr, tmin = 0.0)
     return quote
         empty!(__inf_timing__)
-        empty!(__inf_callees__)
+        #empty!(__inf_callees__)
         empty!(__inf_callee_edges4__)
         start_timing()
         try

--- a/src/parcel_snoopi.jl
+++ b/src/parcel_snoopi.jl
@@ -472,6 +472,7 @@ function _measure_inference_timings(init_commands, infilename, outfilename, flag
     # launch it as a command.
     code_object = """
             using Serialization
+            import Random
             while !eof(stdin)
                 Core.eval(Main, deserialize(stdin))
             end
@@ -496,7 +497,7 @@ function _measure_inference_timings(init_commands, infilename, outfilename, flag
             function time_all_nodes(leaves, graph::Dict, seen::Set, out_times::Dict)
                 # Breadth-first search over the nodes graph, only touching each element once
                 # Start by enqueing all leaves.
-                queue = copy(leaves)
+                queue = Random.shuffle(copy(leaves))
                 while !isempty(queue)
                     node = pop!(queue)
                     if node in seen

--- a/src/parcel_snoopi.jl
+++ b/src/parcel_snoopi.jl
@@ -510,7 +510,8 @@ function _measure_inference_timings(init_commands, infilename, outfilename, flag
                 end
             end
             function time_type_inference(tt::Type, out_times::Dict)
-                _, time = @timed code_typed(tt)
+                # TODO: Check how new code_typed_by_type() is, will this work in 1.5?
+                _, time = @timed Base.code_typed_by_type(tt)
                 out_times[tt] = time
             end
 


### PR DESCRIPTION
Builds on https://github.com/JuliaLang/julia/pull/37535 to expose this information through SnoopCompileCore