### PR TITLE
Deprecate SnoopCompileBot in favor of CompileBot

### DIFF
--- a/SnoopCompileBot/Project.toml
+++ b/SnoopCompileBot/Project.toml
@@ -1,0 +1,13 @@
+name = "SnoopCompileBot"
+uuid = "1d5e0e55-7d74-4714-b8d8-efa80e938cf7"
+author = ["Amin Yahyaabadi <aminyahyaabadi74@gmail.com>"]
+version = "2.0.0"
+
+[deps]
+CompileBot = "877fb49a-56b0-480a-9049-319c0c353852"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+
+[compat]
+CompileBot = "< 2"
+Reexport = "0.2"
+julia = "1"

--- a/SnoopCompileBot/README.md
+++ b/SnoopCompileBot/README.md
@@ -1,0 +1,3 @@
+# SnoopCompileBot
+
+This package is deprecated and renamed to CompileBot. See https://github.com/aminya/CompileBot.jl.

--- a/SnoopCompileBot/src/SnoopCompileBot.jl
+++ b/SnoopCompileBot/src/SnoopCompileBot.jl
@@ -1,0 +1,11 @@
+module SnoopCompileBot
+
+@warn """This package is deprecated and renamed to CompileBot. See https://github.com/aminya/CompileBot.jl for more information."""
+
+using Reexport
+
+@reexport using CompileBot
+
+
+
+end # module


### PR DESCRIPTION
This deprecates SnoopCompileBot in favor of CompileBot. 

Because SnoopCopmileBot was in a sub-directory of this repository, changing the URL is not possible due to git limitations. I decided to rename the package.

I would appreciate it if you can merge this and register a new version for SnoopCompileBot. Then, remove the directory when the registration is done.

https://github.com/JuliaRegistries/General/pull/22253
https://github.com/JuliaRegistries/General/pull/19557
https://github.com/JuliaRegistries/General/pull/21615