### PR TITLE
Fix isdefined check on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - '1.0'
           - '1.2'
           - '1.4'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -24,11 +24,9 @@ ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-JLD = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
 MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AbstractTrees", "ColorTypes", "Documenter", "FixedPointNumbers", "InteractiveUtils", "JLD", "MethodAnalysis", "Pkg", "SparseArrays", "Test"]
+test = ["AbstractTrees", "ColorTypes", "Documenter", "FixedPointNumbers", "InteractiveUtils", "MethodAnalysis", "Pkg", "Test"]

--- a/src/parcel_snoopc.jl
+++ b/src/parcel_snoopc.jl
@@ -79,6 +79,16 @@ function parse_call(line; subst=Vector{Pair{String, String}}(), exclusions=Strin
 
     check = Meta.isexpr(func, :call) && length(func.args) == 3 && func.args[1] == :getfield
     name = (check ? func.args[3].args[2] : "")
+    if !check
+        if occursin("var\"", repr(func))
+            check = true
+            name = func.args[end]
+            if isa(name, QuoteNode)
+                name = name.value
+            end
+            name = String(name)::String
+        end
+    end
 
     # make some substitutions to try to form a leaf types tuple
     changed = false


### PR DESCRIPTION
This looks for the `var` syntax and also decouples the test from JLD, since any package might change and break the test.