### PR TITLE
Add accumulate_by_method

### DIFF
--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -4,7 +4,7 @@ using SnoopCompileCore
 export @snoopc
 isdefined(SnoopCompileCore, Symbol("@snoopi")) && export @snoopi
 if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
-    export @snoopi_deep, flamegraph, flatten_times, accumulate_by_method
+    export @snoopi_deep, flamegraph, flatten_times, accumulate_by_source
 end
 if isdefined(SnoopCompileCore, Symbol("@snoopr"))
     export @snoopr, uinvalidated, invalidation_trees, filtermod, findcaller, ascend

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -4,7 +4,7 @@ using SnoopCompileCore
 export @snoopc
 isdefined(SnoopCompileCore, Symbol("@snoopi")) && export @snoopi
 if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
-    export @snoopi_deep, flamegraph, flatten_times
+    export @snoopi_deep, flamegraph, flatten_times, accumulate_by_method
 end
 if isdefined(SnoopCompileCore, Symbol("@snoopr"))
     export @snoopr, uinvalidated, invalidation_trees, filtermod, findcaller, ascend

--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -13,7 +13,9 @@ Flatten the execution graph of Timings returned from `@snoopi_deep` into a Vecto
 with the exclusive time for each invocation of type inference, skipping any frames that
 took less than `tmin_secs` seconds. Results are sorted by time.
 
-`ROOT` is a dummy element whose time corresponds to the total time for the operation, not just inference time.
+`ROOT` is a dummy element whose time corresponds to the sum of time spent outside inference. It's
+the total time of the operation minus the total time for inference. You can run `sum(first.(result[1:end-1]))`
+to get the total inference time, and `sum(first.(result))` to get the total time overall.
 """
 function flatten_times(timing::Core.Compiler.Timings.Timing; tmin_secs = 0.0)
     out = Pair{Float64,Core.Compiler.Timings.InferenceFrameInfo}[]

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -33,12 +33,12 @@ using AbstractTrees  # For FlameGraphs tests
     longest_frame_time = times[end][1]
     @test length(flatten_times(timing, tmin_secs=longest_frame_time)) == 1
 
-    timesm = accumulate_by_method(times)
+    timesm = accumulate_by_source(times)
     @test length(timesm) == 4
     names = [m.name for (time, m) in timesm]
     @test sort(names) == [:ROOT, :g, :h, :i]
     longest_method_time = timesm[end][1]
-    @test length(accumulate_by_method(times; tmin_secs=longest_method_time)) == 1
+    @test length(accumulate_by_source(times; tmin_secs=longest_method_time)) == 1
 end
 
 @testset "flamegraph_export" begin


### PR DESCRIPTION
This analysis tool is useful to detect methods that get a crazy number
of specializations. These are candidates for refactoring into smaller,
more independent chunks or nospecialize annotations.