### PR TITLE
Fix tests on nightly

### DIFF
--- a/test/snoopi.jl
+++ b/test/snoopi.jl
@@ -65,7 +65,11 @@ uncompiled(x) = x + 1
 
     # Identify kwfuncs, whose naming depends on the Julia version (issue #46)
     # Also check for kw body functions (also tested below)
-    tinf = @snoopi sortperm(rand(5); rev=true)
+    tinf = @snoopi begin
+        FuncKinds.fsort()
+        FuncKinds.fsort2()
+        FuncKinds.fsort3()
+    end
     pc = SnoopCompile.parcel(tinf)
     FK = pc[:Base]
     @test any(str->occursin("kwftype", str), FK)

--- a/test/testmodules/FuncKinds.jl
+++ b/test/testmodules/FuncKinds.jl
@@ -100,4 +100,8 @@ f5(x::Array{Float64,K}; y::Int=0) where K = K
 # Default and keyword args
 f6(x, y="hello"; z::Int=0) = 1
 
+fsort() = @eval sortperm(rand(5); rev=true, by=sin)
+fsort2() = @eval sortperm(rand(5); rev=true, by=x->x^2)
+fsort3() = sortperm(rand(Float16, 5))
+
 end


### PR DESCRIPTION
I'm not sure which change broke this, but I suspect it's changes in `repr` module-scoping, adding `Main` in front of more things which then get excluded. This is a more typical test set anyway, so this is probably a good change in any case.

The `@eval`s are necessary to trigger a fresh entrance into inference.