### PR TITLE
Require method ownership

### DIFF
--- a/src/parcel_snoopi.jl
+++ b/src/parcel_snoopi.jl
@@ -247,11 +247,15 @@ function parcel(tinf::AbstractVector{Tuple{Float64, Core.MethodInstance}};
         # need to be defined; we collect all the corresponding modules and assign it to the
         # "topmost".
         empty!(mods)
-        push!(mods, Base.moduleroot(m.module))
+        mroot = Base.moduleroot(m.module)
+        push!(mods, mroot)
         addmodules!(mods, tt.parameters)
         topmod = topmodule(mods)
         if topmod === nothing
             @debug "Skipping $tt due to lack of a suitable top module"
+            continue
+        elseif topmod !== mroot
+            @debug "Skipping $tt due to lack of method ownership"
             continue
         end
         # If we haven't yet started the list for this module, initialize

--- a/test/snoopi.jl
+++ b/test/snoopi.jl
@@ -72,7 +72,8 @@ uncompiled(x) = x + 1
     end
     pc = SnoopCompile.parcel(tinf)
     FK = pc[:Base]
-    @test any(str->occursin("kwftype", str), FK)
+    @test  any(str->occursin("kwftype", str), FK)
+    @test !any(str->occursin(r"Type\{NamedTuple.*typeof\(sin\)", str), FK)
     if VERSION >= v"1.4.0-DEV.215"
         @test any(str->occursin("__lookup_kwbody__", str), FK)
     else


### PR DESCRIPTION
Based on poking around Julia's `src/dump.c`, it's my understanding
that a *disconnected* (backedge-free) `MethodInstance` needs to be
cached in the module owning the `Method`.
The implication is that Base methods that get called on
package-defined objects cannot be cached on their own merits, so we
should exclude such `MethodInstance`s.

The way to fix this is to make such calls inferrable,
in which case they will be cached in the package module thanks to
their backedges.