### PR TITLE
Don't leave the flamegraph headless in tests

### DIFF
--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -53,7 +53,8 @@ end
     end
 
     t1, t2 = times[1][1], times[2][1]
-    if t1 != t2   # in rare cases it happens that the bottom two have the same time, but the test requires a gap
+    # Ensure there's a timing gap, and that cutting off the fastest-to-infer won't leave the tree headless
+    if t1 != t2 && times[1][2].mi.def.name !== :g
         cutoff_bottom_frame = (t1 + t2) / 2
         fg2 = SnoopCompile.flamegraph(timing, tmin_secs = cutoff_bottom_frame)
         @test length(collect(AbstractTrees.PreOrderDFS(fg2))) == (length(collect(AbstractTrees.PreOrderDFS(fg))) - 1)


### PR DESCRIPTION
The fix in #155 was incomplete, this should do it.