### PR TITLE
Add `module_roots`

### DIFF
--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -4,7 +4,7 @@ using SnoopCompileCore
 export @snoopc
 isdefined(SnoopCompileCore, Symbol("@snoopi")) && export @snoopi
 if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
-    export @snoopi_deep, flamegraph, flatten_times, accumulate_by_source
+    export @snoopi_deep, flamegraph, flatten_times, accumulate_by_source, module_roots
 end
 if isdefined(SnoopCompileCore, Symbol("@snoopr"))
     export @snoopr, uinvalidated, invalidation_trees, filtermod, findcaller, ascend


### PR DESCRIPTION
`module_roots` makes it easier to discover precompile-worthy
MethodInstances. The promise of `@snoopi_deep` is that it is not
restricted to just the entrance calls to inference; consequently,
we can find the most-expensive-to-infer calls in a specific module and
precompile those calls.

We may want to rewrite the entire `parcel` infrastructure around this, but perhaps one step at a time. We might want to create some kind of aggregate report that combines analysis of excessive specialization, inference breaks, and an improved set of precompile statements.