### PR TITLE
Dramatically improve `flamegraph(timing)` performance

### DIFF
--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -110,10 +110,16 @@ function frame_name(mi::Core.Compiler.MethodInstance)
 end
 # Special printing for Type Tuples so they're less ugly in the FlameGraph
 function frame_name(name, @nospecialize(tt::Type{<:Tuple}))
-    io = IOBuffer()
-    Base.show_tuple_as_call(io, name, tt)
-    v = String(take!(io))
-    return v
+    try
+        io = IOBuffer()
+        Base.show_tuple_as_call(io, name, tt)
+        v = String(take!(io))
+        return v
+    catch e
+        e isa InterruptException && rethrow()
+        @warn "Error displaying frame: $e"
+        return name
+    end
 end
 
 # NOTE: The "root" node doesn't cover the whole profile, because it's only the _complement_

--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -109,9 +109,9 @@ function frame_name(mi::Core.Compiler.MethodInstance)
     frame_name(mi.def.name, mi.specTypes)
 end
 # Special printing for Type Tuples so they're less ugly in the FlameGraph
-function frame_name(name, ::Type{TT}) where TT<:Tuple
+function frame_name(name, @nospecialize(tt::Type{<:Tuple}))
     io = IOBuffer()
-    Base.show_tuple_as_call(io, name, TT)
+    Base.show_tuple_as_call(io, name, tt)
     v = String(take!(io))
     return v
 end


### PR DESCRIPTION
Move method instance's specTypes Type Tuple from a compile-time argument
to a runtime argument, to prevent compiling a specialization for every
_value_ in the data!

I hadn't meant to write it that way in the first place, I had just done
it absent-mindedly, because `specTypes` is a Type, so I hadn't thought
about moving it back into the value domain.

We used `@snoopi_deep` to find out the problem and fix this performance
problem! It's neat to see it profiling itself! :tada:

Fixes https://github.com/timholy/SnoopCompile.jl/issues/150.