### PR TITLE
Add `inference_triggers`

### DIFF
--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -3,13 +3,6 @@ module SnoopCompile
 using SnoopCompileCore
 export @snoopc
 # More exports are defined below in the conditional loading sections
-isdefined(SnoopCompileCore, Symbol("@snoopi")) &&
-if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
-
-end
-if isdefined(SnoopCompileCore, Symbol("@snoopr"))
-
-end
 
 using Core: MethodInstance, CodeInfo
 using Serialization, OrderedCollections
@@ -34,6 +27,7 @@ end
 if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
     include("parcel_snoopi_deep.jl")
     export @snoopi_deep, flamegraph, flatten_times, accumulate_by_source, runtime_inferencetime
+    export inference_breaks, collect_callerinstances, callingframe
 end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopl"))

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -27,7 +27,7 @@ end
 if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
     include("parcel_snoopi_deep.jl")
     export @snoopi_deep, flamegraph, flatten_times, accumulate_by_source, runtime_inferencetime
-    export inference_breaks, collect_callerinstances, callingframe
+    export inference_triggers, callerinstance, callingframe
 end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopl"))

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -63,7 +63,7 @@ using AbstractTrees  # For FlameGraphs tests
     @test length(timesmod) == 1
 end
 
-@testset "inference_breaks" begin
+@testset "inference_triggers" begin
     myplus(x, y) = x + y    # freshly redefined even if tests are re-run
     function f(x)
         x < 0.25 ? 1 :
@@ -72,26 +72,26 @@ end
     end
     g(c) = myplus(f(c[1]), f(c[2]))
     tinf = @snoopi_deep g([0.7, 0.8])
-    @test length(inference_breaks(tinf; exclude_toplevel=false)) == 2
-    ibs = inference_breaks(tinf)
-    ib = only(ibs)
+    @test length(inference_triggers(tinf; exclude_toplevel=false)) == 2
+    itrigs = inference_triggers(tinf)
+    itrig = only(itrigs)
     io = IOBuffer()
-    show(io, ib)
+    show(io, itrig)
     str = String(take!(io))
-    @test occursin(r"costing [0-9\.]+s", str)
-    @test occursin(r"MethodInstance for .*myplus.*(::UInt8, ::Float16)", str)
-    @test occursin("from g at", str)
-    mis = collect_callerinstances(ib, tinf)
+    @test occursin(r"MethodInstance for .*myplus.*\(::UInt8, ::Float16\)", str)
+    @test occursin("from g", str)
+    @test occursin(r"with specialization .*::Vector\{Float64\}", str)
+    mis = callerinstance.(itrigs)
     @test only(mis).def == which(g, (Any,))
-    @test callingframe(ib).st[1].func === :eval
+    @test callingframe(itrig).callerframes[1].func === :eval
 
     mysqrt(x) = sqrt(x)
     c = Any[1, 1.0, 0x01, Float16(1)]
     tinf = @snoopi_deep map(mysqrt, c)
-    ibs = inference_breaks(tinf)
-    libs = accumulate_by_source(ibs)
-    show(io, libs)
-    @test any(str->occursin("4 instances", str), split(String(take!(io)), '\n'))
+    itrigs = inference_triggers(tinf)
+    loctrigs = accumulate_by_source(itrigs)
+    show(io, loctrigs)
+    @test any(str->occursin("4 callees from 2 callers", str), split(String(take!(io)), '\n'))
 end
 
 @testset "flamegraph_export" begin


### PR DESCRIPTION
This adds a lot of exports, but the analysis of the callees and callers at breaks
in inference chains is fairly complicated. These utilities streamline the analysis.

This requires https://github.com/JuliaLang/julia/pull/38566