### PR TITLE
Add parcel for snoopi_deep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,9 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AbstractTrees", "ColorTypes", "Documenter", "FixedPointNumbers", "InteractiveUtils", "MethodAnalysis", "Pkg", "Test"]
+test = ["AbstractTrees", "ColorTypes", "Documenter", "FixedPointNumbers", "InteractiveUtils", "MethodAnalysis", "Random", "Pkg", "Test"]

--- a/src/write.jl
+++ b/src/write.jl
@@ -1,5 +1,5 @@
 # Write precompiles for userimg.jl
-function write(io::IO, pc::Vector)
+function write(io::IO, pc::Vector{<:AbstractString})
     for ln in pc
         println(io, ln)
     end
@@ -10,10 +10,11 @@ function write(filename::AbstractString, pc::Vector)
     if !isdir(path)
         mkpath(path)
     end
+    ret = nothing
     open(filename, "w") do io
-        write(io, pc)
+        ret = write(io, pc)
     end
-    nothing
+    return ret
 end
 
 """

--- a/test/testmodules/SnoopBench.jl
+++ b/test/testmodules/SnoopBench.jl
@@ -1,0 +1,25 @@
+module SnoopBench
+
+# Assignment of parcel to modules
+struct A end
+f3(::A) = 1
+f2(a::A) = f3(a)
+f1(a::A) = f2(a)
+
+# Like map! except it uses push!
+# With a single call site
+mappushes!(f, dest, src) = (for item in src push!(dest, f(item)) end; return dest)
+mappushes(@nospecialize(f), src) = mappushes!(f, [], src)
+function mappushes3!(f, dest, src)
+    # A version with multiple call sites
+    item1 = src[1]
+    push!(dest, item1)
+    item2 = src[2]
+    push!(dest, item2)
+    item3 = src[3]
+    push!(dest, item3)
+    return dest
+end
+mappushes3(@nospecialize(f), src) = mappushes3!(f, [], src)
+
+end


### PR DESCRIPTION
This is the analog of our previous functionality for `@snoopi_deep`. It works by finding the root-most frame in each branch that owns the method being called and which can `eval` all the types in the signature. 

In most respects this probably replaces #157, and really should probably replace the `parcel`/`write` style when using `@snoopi`; that seems to have nothing but disadvantages compared to this PR. (But it's still young, so let's give it a little while to mature before we think about clearing out cruft.)