### PR TITLE
Option to consolidate consts in inference timing

### DIFF
--- a/src/visualizations.jl
+++ b/src/visualizations.jl
@@ -40,3 +40,6 @@ function specialization_plot(ridata; kwargs...)
     fig, ax = plt.subplots()
     return specialization_plot(ax, ridata; kwargs...)
 end
+
+specialization_plot(ax::PyCall.PyObject, tinf::Timing; consts::Bool=true, kwargs...) = specialization_plot(ax, runtime_inferencetime(tinf; consts); kwargs...)
+specialization_plot(tinf::Timing; consts::Bool=true, kwargs...) = specialization_plot(runtime_inferencetime(tinf; consts); kwargs...)


### PR DESCRIPTION
This allows one to optionally consolidate information about
inference with different Const values to their base MethodInstance.
It also adds a convenience method for visualizing directly from the
timing data.