### PR TITLE
Improve parcel for deep

### DIFF
--- a/src/parcel_snoopi.jl
+++ b/src/parcel_snoopi.jl
@@ -225,7 +225,7 @@ function handle_kwbody(topmod::Module, m::Method, paramrepr, tt, fstr="fbody"; c
     end
     fparent = getfield(m.module, nameparent)
     pttstr = tuplestring(paramrepr[m.nkw+2:end])
-    whichstr = "which($(repr(fparent)), $pttstr)"
+    whichstr = "which($nameparent, $pttstr)"
     can1, exc1 = can_eval(topmod, whichstr, check_eval)
     if can1
         ttstr = tuplestring(paramrepr)
@@ -336,7 +336,7 @@ function add_repr!(list, modgens::Dict{Module, Vector{Method}}, mi::MethodInstan
     if mkw !== nothing
         # Keyword function
         fname = mkw.captures[1] === nothing ? mkw.captures[2] : mkw.captures[1]
-        fkw = "Core.kwftype(typeof($mmod.$fname))"
+        fkw = "Core.kwftype(typeof($fname))"
         return add_if_evals!(list, topmod, fkw, paramrepr, tt; check_eval=check_eval, time=time)
     elseif mkwbody !== nothing
         ret = handle_kwbody(topmod, m, paramrepr, tt; check_eval = check_eval)
@@ -360,11 +360,11 @@ function add_repr!(list, modgens::Dict{Module, Vector{Method}}, mi::MethodInstan
                 csigstr = tuplestring(cparamrepr)
                 mkwc = match(kwbodyrex, cname)
                 if mkwc === nothing
-                    getgen = "typeof(which($cmod.$(caller.name),$csigstr).generator.gen)"
+                    getgen = "typeof(which($(caller.name),$csigstr).generator.gen)"
                     return add_if_evals!(list, topmod, getgen, paramrepr, tt; check_eval=check_eval, time=time)
                 else
                     if VERSION >= v"1.4.0-DEV.215"
-                        getgen = "which(Core.kwfunc($cmod.$(mkwc.captures[1])),$csigstr).generator.gen"
+                        getgen = "which(Core.kwfunc($(mkwc.captures[1])),$csigstr).generator.gen"
                         ret = handle_kwbody(topmod, caller, cparamrepr, tt; check_eval = check_eval) #, getgen)
                         if ret !== nothing
                             push!(list, append_time(ret, time))

--- a/test/snoopi.jl
+++ b/test/snoopi.jl
@@ -110,13 +110,13 @@ uncompiled(x) = x + 1
     FK = pc[:FuncKinds]
     @test any(str->occursin("precompile(Tuple{typeof(gen),Float32})", str), FK)
     @test any(str->occursin("precompile(Tuple{typeof(gen2),$Int,Float64})", str), FK)
-    @test any(str->occursin("typeof(which(FuncKinds.gen2,($Int,Any,)).generator.gen)", str), FK)
+    @test any(str->occursin("typeof(which(gen2,($Int,Any,)).generator.gen)", str), FK)
     @test any(str->occursin("precompile(Tuple{typeof(genkw1)})", str), FK)
     @test !any(str->occursin("precompile(Tuple{typeof(genkw2)})", str), FK)
-    @test any(str->occursin("Tuple{Core.kwftype(typeof(FuncKinds.genkw2)),NamedTuple{(:b,),$(SP)Tuple{String}},typeof(genkw2)}", str), FK)
+    @test any(str->occursin("Tuple{Core.kwftype(typeof(genkw2)),NamedTuple{(:b,),$(SP)Tuple{String}},typeof(genkw2)}", str), FK)
     if VERSION >=  v"1.4.0-DEV.215"
-        @test any(str->occursin("__lookup_kwbody__(which(FuncKinds.genkw1, ()))", str), FK)
-        @test any(str->occursin("__lookup_kwbody__(which(FuncKinds.genkw2, ()))", str), FK)
+        @test any(str->occursin("__lookup_kwbody__(which(genkw1, ()))", str), FK)
+        @test any(str->occursin("__lookup_kwbody__(which(genkw2, ()))", str), FK)
     else
         @test any(str->occursin("isdefined", str), FK)
     end
@@ -177,19 +177,19 @@ end
     @test any(str->occursin("typeof(f4),$Int,$Int", str), FK)
     @test any(str->occursin("typeof(f4),$UInt,String", str), FK)
     @test any(str->occursin("typeof(f4),$(Matrix{Float64})", str), FK)
-    @test any(str->occursin(r"kwftype\(typeof\(FuncKinds.f5.*:y.*Int8", str), FK)
+    @test any(str->occursin(r"kwftype\(typeof\(f5.*:y.*Int8", str), FK)
     @test any(str->occursin("typeof(f5),Int16", str), FK)
     @test any(str->occursin("typeof(f5),Int32", str), FK)
     if "$(Matrix{Float64})" == "Matrix{Float64}"
-        @test any(str->occursin(r"kwftype\(typeof\(FuncKinds.f5.*:y.*Matrix\{Float64\}", str), FK)
+        @test any(str->occursin(r"kwftype\(typeof\(f5.*:y.*Matrix\{Float64\}", str), FK)
     else
-        @test any(str->occursin(r"kwftype\(typeof\(FuncKinds.f5.*:y.*Array\{Float64,2\}", str), FK)
+        @test any(str->occursin(r"kwftype\(typeof\(f5.*:y.*Array\{Float64,2\}", str), FK)
     end
-    # @test any(str->occursin("typeof(FuncKinds.f6),(1, "hi"; z=8) == 1
-    # @test any(str->occursin("typeof(FuncKinds.f7),(1, (1, :hi)) == 1
-    # @test any(str->occursin("typeof(FuncKinds.f8),(0) == 1
-    # @test any(str->occursin("typeof(FuncKinds.f9),(3) == 9
-    # @test any(str->occursin("typeof(FuncKinds.f9),(3.0) == 3.0
+    # @test any(str->occursin("typeof(f6),(1, "hi"; z=8) == 1
+    # @test any(str->occursin("typeof(f7),(1, (1, :hi)) == 1
+    # @test any(str->occursin("typeof(f8),(0) == 1
+    # @test any(str->occursin("typeof(f9),(3) == 9
+    # @test any(str->occursin("typeof(f9),(3.0) == 3.0
 
 end
 

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -102,6 +102,9 @@ include("testmodules/SnoopBench.jl")
     t, mi = only(tmis)
     @test ttot == tmod == t  # since there is only one
     @test mi.def.name === :f1
+    ttot2, prs = SnoopCompile.parcel(tinf; tmin=10.0)
+    @test isempty(prs)
+    @test ttot2 == ttot
 
     A = [a]
     tinf = @snoopi_deep SnoopBench.mappushes(identity, A)


### PR DESCRIPTION
This allows:
- excluding specific modules, forcing it to choose a deeper call for the root
- is more consistent about time: now it's consistent about MethodInstances
  (dropping the Consts, which are not precompilable) and keeping the longest
  time for that MethodInstance.
- allow a tmin parameter to suppress branches that drop below a threshold
  inclusive time