### PR TITLE
Export InclusiveTiming and its constructor

### DIFF
--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -27,7 +27,7 @@ end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
     include("parcel_snoopi_deep.jl")
-    export @snoopi_deep, flamegraph, flatten_times, accumulate_by_source, runtime_inferencetime
+    export @snoopi_deep, InclusiveTiming, flamegraph, flatten_times, accumulate_by_source, runtime_inferencetime
     export inference_triggers, callerinstance, callingframe
 end
 

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -49,7 +49,7 @@ using AbstractTrees  # For FlameGraphs tests
     longest_method_time = timesm[end][1]
     @test length(accumulate_by_source(times; tmin_secs=longest_method_time)) == 1
 
-    itiming = SnoopCompile.build_inclusive_times(timing)
+    itiming = InclusiveTiming(timing)
     @test SnoopCompile.isROOT(Core.MethodInstance(itiming))
     @test SnoopCompile.isROOT(Method(itiming))
     itimes = flatten_times(itiming)


### PR DESCRIPTION
`build_inclusive_timing` is really just a constructor for
`InclusiveTiming` objects, so we might as well spell it that way.
It's also clearly useful as an exported entity.