### PR TITLE
More informative error for child-node itrigs

### DIFF
--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -497,6 +497,7 @@ function inference_triggers(t::Timing; exclude_toplevel::Bool=true)
     end
 
     itrigs = map(t.children) do tc
+        tc.bt === nothing && throw(ArgumentError("it seems you've supplied a child node, but backtraces are collected only at the entrance to inference"))
         InferenceTrigger(MethodInstance(tc), first_julia_frame(tc.bt)..., tc.bt)
     end
     if exclude_toplevel

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -110,6 +110,7 @@ end
     mis = callerinstance.(itrigs)
     @test only(mis).def == which(g, (Any,))
     @test callingframe(itrig).callerframes[1].func === :eval
+    @test_throws ArgumentError("it seems you've supplied a child node, but backtraces are collected only at the entrance to inference") inference_triggers(tinf.children[1])
 
     # Where the caller is inlined into something else
     callee(x) = 2x


### PR DESCRIPTION
It's natural to hope to collect inference triggers in just
a child node, but these are not preserved (for good reason).
At least we should throw an explanatory error.