### PR TITLE
Skip higher-order funcs for inference triggers

### DIFF
--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -28,7 +28,7 @@ end
 if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
     include("parcel_snoopi_deep.jl")
     export @snoopi_deep, InclusiveTiming, flamegraph, flatten_times, accumulate_by_source, runtime_inferencetime
-    export inference_triggers, callerinstance, callingframe
+    export inference_triggers, callerinstance, callingframe, skiphigherorder
 end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopl"))


### PR DESCRIPTION
When identifying the caller of an inference-triggering callee,
sometimes it's nice to skip over higher order functions.
For instance in a `do`-block, you might prefer to attribute
any inference trigger in the anonymous function to the parent
scope that implemented the `do`-block rather than the
higher-order function used by the `do`-statement.