### PR TITLE
`ascend` integration and docs cleanup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
-Cthulhu = "1.2"
+Cthulhu = "1.5"
 FlameGraphs = "0.2"
 OrderedCollections = "1"
 Requires = "1"

--- a/docs/src/snoopr.md
+++ b/docs/src/snoopr.md
@@ -93,6 +93,7 @@ julia> trees = invalidation_trees(invalidations)
  inserting f(::Float64) in Main at REPL[9]:1 invalidated:
    backedges: 1: superseding f(::Real) in Main at REPL[2]:1 with MethodInstance for f(::Float64) (2 children)
               2: superseding f(::Real) in Main at REPL[2]:1 with MethodInstance for f(::AbstractFloat) (2 children)
+   1 mt_cache
 ```
 
 The output, `trees`, is a vector of `MethodInvalidations`, a data type defined in `SnoopCompile`; each of these is the set of invalidations triggered by a particular method definition.

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -1,3 +1,48 @@
+"""
+SnoopCompile allows you to collect and analyze data on actions of Julia's compiler.
+
+The capabilities depend on your version of Julia; in general, the capabilities that
+require more recent Julia versions are also the most powerful and useful. When possible,
+you should prefer them above the more limited tools available on earlier versions.
+
+## All Julia versions
+
+- `@snoopc`: record Julia's code generation
+- `SnoopCompile.read`: parse data collected from `@snoopc`
+- `SnoopCompile.parcel`: split precompile statements into modules/packages
+- `SnoopCompile.write`: write module-specific precompile files (")
+
+## At least Julia 1.2
+
+- `@snoopi`: record entrances to Julia's type-inference (`parcel` and `write` work on these data, too)
+
+## At least Julia 1.6
+
+### Invalidations
+
+- `@snoopr`: record invalidations
+- `uinvalidated`: collect unique method invalidations from `@snoopr`
+- `invalidation_trees`: organize invalidation data into trees
+- `filtermod`: select trees that invalidate methods in particular modules
+- `findcaller`: find a path through invalidation trees reaching a particular method
+- `ascend`: interactive analysis of an invalidation tree
+
+### LLVM
+
+- `@snoopl`: record data about the actions of LLVM, the library used to generate native code
+- `read_snoopl`: parse data collected by `@snoopl`
+
+### "Deep" data on inference
+
+- `@snoopi_deep`: record more extensive data about type-inference (`parcel` and `write` work on these data, too)
+- `flamegraph`: prepare a visualization from `@snoopi_deep`
+- `flatten_times`: reduce the tree format recorded by `@snoopi_deep` to list format
+- `accumulate_by_source`: aggregate list items by their source
+- `inference_triggers`: extract data on the triggers of inference
+- `callerinstance`, `callingframe`, `skiphigherorder`, and `InferenceTrigger`: manipulate stack frames from `inference_triggers`
+- `ascend`: interactive analysis of an inference-triggering call chain
+- `runtime_inferencetime`: profile-guided deoptimization
+"""
 module SnoopCompile
 
 using SnoopCompileCore
@@ -27,8 +72,9 @@ end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
     include("parcel_snoopi_deep.jl")
+    include("deep_demos.jl")
     export @snoopi_deep, InclusiveTiming, flamegraph, flatten_times, accumulate_by_source, runtime_inferencetime
-    export inference_triggers, callerinstance, callingframe, skiphigherorder
+    export InferenceTrigger, inference_triggers, callerinstance, callingframe, skiphigherorder
 end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopl"))

--- a/src/deep_demos.jl
+++ b/src/deep_demos.jl
@@ -1,0 +1,108 @@
+"""
+    tinf = SnoopCompile.itrigs_demo()
+
+A simple demonstration of collecting inference triggers. This demo defines a module
+
+```julia
+module ItrigDemo
+@noinline double(x) = 2x
+@inline calldouble1(c) = double(c[1])
+calldouble2(cc) = calldouble1(cc[1])
+calleach(ccs) = (calldouble2(ccs[1]), calldouble2(ccs[2]))
+end
+```
+
+It then "warms up" (forces inference on) `calldouble2(::Vector{Vector{Any}})`, `calldouble1(::Vector{Any})`, `double(::Int)`:
+
+```julia
+cc = [Any[1]]
+ItrigDemo.calleach([cc,cc])
+```
+
+Then it collects and returns inference data using
+
+```julia
+cc1, cc2 = [Any[0x01]], [Any[1.0]]
+@snoopi_deep ItrigDemo.calleach([cc1, cc2])
+```
+
+This does not require any new inference for `calldouble2` or `calldouble1`, but it does force inference on `double` with two new types.
+See [`inference_triggers`](@ref) to see what gets collected and returned.
+"""
+function itrigs_demo()
+    eval(:(
+        module ItrigDemo
+        @noinline double(x) = 2x
+        @inline calldouble1(c) = double(c[1])
+        calldouble2(cc) = calldouble1(cc[1])
+        calleach(ccs) = (calldouble2(ccs[1]), calldouble2(ccs[2]))
+        end
+    ))
+    # Call once to infer `calldouble2(::Vector{Vector{Any}})`, `calldouble1(::Vector{Any})`, `double(::Int)`
+    cc = [Any[1]]
+    Base.invokelatest(ItrigDemo.calleach, [cc,cc])
+    # Now use UInt8 & Float64 elements to force inference on double, without forcing new inference on its callers
+    cc1, cc2 = [Any[0x01]], [Any[1.0]]
+    return @snoopi_deep Base.invokelatest(ItrigDemo.calleach, [cc1, cc2])
+end
+
+"""
+    tinf = SnoopCompile.itrigs_higherorder_demo()
+
+A simple demonstration of handling higher-order methods with inference triggers. This demo defines a module
+
+```julia
+module ItrigHigherOrderDemo
+double(x) = 2x
+@noinline function mymap!(f, dst, src)
+    for i in eachindex(dst, src)
+        dst[i] = f(src[i])
+    end
+    return dst
+end
+@noinline mymap(f::F, src) where F = mymap!(f, Vector{Any}(undef, length(src)), src)
+callmymap(src) = mymap(double, src)
+end
+```
+
+The key feature of this set of definitions is that the function `double` gets passed as an argument
+through `mymap` and `mymap!` (the latter are [higher-order functions](https://en.wikipedia.org/wiki/Higher-order_function)).
+
+It then "warms up" (forces inference on) `callmymap(::Vector{Any})`, `mymap(::typeof(double), ::Vector{Any})`,
+`mymap!(::typeof(double), ::Vector{Any}, ::Vector{Any})` and `double(::Int)`:
+
+```julia
+ItrigHigherOrderDemo.callmymap(Any[1, 2])
+```
+
+Then it collects and returns inference data using
+
+```julia
+@snoopi_deep ItrigHigherOrderDemo.callmymap(Any[1.0, 2.0])
+```
+
+which forces inference for `double(::Float64)`.
+
+See [`skiphigherorder`](@ref) for an example using this demo.
+"""
+function itrigs_higherorder_demo()
+    eval(:(
+        module ItrigHigherOrderDemo
+        double(x) = 2x
+        @noinline function mymap!(f, dst, src)
+            for i in eachindex(dst, src)
+                dst[i] = f(src[i])
+            end
+            return dst
+        end
+        @noinline mymap(f::F, src) where F = mymap!(f, Vector{Any}(undef, length(src)), src)
+        callmymap(src) = mymap(double, src)
+        end
+    ))
+    # Call once to infer `callmymap(::Vector{Any})`, `mymap(::typeof(double), ::Vector{Any})`,
+    #    `mymap!(::typeof(double), ::Vector{Any}, ::Vector{Any})` and `double(::Int)`
+    Base.invokelatest(ItrigHigherOrderDemo.callmymap, Any[1, 2])
+    src = Any[1.0, 2.0]   # double not yet inferred for Float64
+    return @snoopi_deep Base.invokelatest(ItrigHigherOrderDemo.callmymap, src)
+end
+


### PR DESCRIPTION
This provides integration with Cthulhu's `ascend`, making it
significantly easier to analyze inference triggers.

The docstrings had also gotten out of date, and this updates them
while also allowing more compact docstrings by moving definitions to a
set of demos.

Finally, this adds an "orientation" docstring to SnoopCompile itself.
These can be helpful in orienting users to the API.