### PR TITLE
Improve accuracy & speed of known_type

### DIFF
--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -133,9 +133,16 @@ function isprecompilable(mi::MethodInstance; excluded_modules=Set([Main::Module]
         if can_eval
             params = Base.unwrap_unionall(mi.specTypes)::DataType
             for p in params.parameters
-                if !known_type(mod, p)
-                    can_eval = false
-                    break
+                if p isa TypeVar
+                    if !known_type(mod, p.ub) || !known_type(mod, p.lb)
+                        can_eval = false
+                        break
+                    end
+                elseif p isa Type
+                    if !known_type(mod, p)
+                        can_eval = false
+                        break
+                    end
                 end
             end
         end

--- a/test/snoopi.jl
+++ b/test/snoopi.jl
@@ -40,6 +40,37 @@ end
     @test occursin("f2#", String(nameof(f)))
 end
 
+@testset "known_type" begin
+    @eval module OtherModule
+        p() = 1
+        q() = 1
+    end
+    @eval module KnownType
+        f() = 1
+        module SubModule
+            g() = 1
+            h() = 1
+        end
+        module Exports
+            export i
+            i() = 1
+            j() = 1
+        end
+        using .SubModule: g
+        using .Exports
+        using Main.OtherModule: p
+    end
+    @test  SnoopCompile.known_type(KnownType, which(KnownType.f, ()).sig)
+    @test  SnoopCompile.known_type(KnownType, which(KnownType.g, ()).sig)
+    @test  SnoopCompile.known_type(KnownType, which(KnownType.SubModule.g, ()).sig)
+    @test  SnoopCompile.known_type(KnownType, which(KnownType.SubModule.h, ()).sig)  # it's reachable if appropriately qualified
+    @test  SnoopCompile.known_type(KnownType, which(KnownType.i, ()).sig)
+    @test  SnoopCompile.known_type(KnownType, which(KnownType.Exports.i, ()).sig)
+    @test  SnoopCompile.known_type(KnownType, which(KnownType.Exports.j, ()).sig)    # it's reachable if appropriately qualified
+    @test  SnoopCompile.known_type(KnownType, which(OtherModule.p, ()).sig)
+    @test !SnoopCompile.known_type(KnownType, which(OtherModule.q, ()).sig)
+end
+
 uncompiled(x) = x + 1
 
 @testset "snoopi" begin

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -248,12 +248,13 @@ include("testmodules/SnoopBench.jl")
     @test length(prs) == 2
     _, (tmodBase, tmis) = prs[findfirst(pr->pr.first === Base, prs)]
     tw, nw = SnoopCompile.write(io, tmis; tmin=0.0)
-    @test 0.0 <= tw <= tmodBase && 0 <= nw <= length(tmis)-1
+    @test 0.0 <= tw <= tmodBase && 0 <= nw <= length(tmis)
     str = String(take!(io))
     @test !occursin(r"Base.Fix2\{typeof\(isequal\).*SnoopBench.A\}", str)
     @test length(split(chomp(str), '\n')) == nw
     _, (tmodBench, tmis) = prs[findfirst(pr->pr.first === SnoopBench, prs)]
-    @test tmodBench + tmodBase ≈ ttot
+    tinc = InclusiveTiming(tinf)
+    @test sum(SnoopCompile.floattime, tinc.children[1:end-1]) <= tmodBench + tmodBase # last child is not precompilable
     tw, nw = SnoopCompile.write(io, tmis; tmin=0.0)
     @test nw == 2
     str = String(take!(io))


### PR DESCRIPTION
This gets `known_type` out of the business of `eval`ing type names and
uses the internal machinery instead.