### PR TITLE
Rename snoopi_deep -> snoopi_tree

### DIFF
--- a/SnoopCompileCore/src/SnoopCompileCore.jl
+++ b/SnoopCompileCore/src/SnoopCompileCore.jl
@@ -12,7 +12,7 @@ if VERSION >= v"1.2.0-DEV.573"
 end
 
 if VERSION >= v"1.6.0-DEV.1190"  # https://github.com/JuliaLang/julia/pull/37749
-    include("snoopi_deep.jl")
+    include("snoopi_tree.jl")
 end
 
 if VERSION >= v"1.6.0-DEV.154"

--- a/SnoopCompileCore/src/snoopi.jl
+++ b/SnoopCompileCore/src/snoopi.jl
@@ -1,4 +1,4 @@
-export @snoopi, @snoopi_deep
+export @snoopi, @snoopi_tree
 
 const __inf_timing__ = Tuple{Float64,MethodInstance}[]
 

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -34,9 +34,9 @@ you should prefer them above the more limited tools available on earlier version
 
 ### "Deep" data on inference
 
-- `@snoopi_deep`: record more extensive data about type-inference (`parcel` and `write` work on these data, too)
-- `flamegraph`: prepare a visualization from `@snoopi_deep`
-- `flatten_times`: reduce the tree format recorded by `@snoopi_deep` to list format
+- `@snoopi_tree`: record more extensive data about type-inference (`parcel` and `write` work on these data, too)
+- `flamegraph`: prepare a visualization from `@snoopi_tree`
+- `flatten_times`: reduce the tree format recorded by `@snoopi_tree` to list format
 - `accumulate_by_source`: aggregate list items by their source
 - `inference_triggers`: extract data on the triggers of inference
 - `callerinstance`, `callingframe`, `skiphigherorder`, and `InferenceTrigger`: manipulate stack frames from `inference_triggers`
@@ -70,11 +70,13 @@ if isdefined(SnoopCompileCore, Symbol("@snoopi"))
     export @snoopi
 end
 
-if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
-    include("parcel_snoopi_deep.jl")
-    include("deep_demos.jl")
-    export @snoopi_deep, InclusiveTiming, flamegraph, flatten_times, accumulate_by_source, runtime_inferencetime
+if isdefined(SnoopCompileCore, Symbol("@snoopi_tree"))
+    include("parcel_snoopi_tree.jl")
+    include("snoopi_tree_demos.jl")
+    export @snoopi_tree, InclusiveTiming, flamegraph, flatten_times, accumulate_by_source, runtime_inferencetime
     export InferenceTrigger, inference_triggers, callerinstance, callingframe, skiphigherorder
+    # deprecated
+    export @snoopi_deep
 end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopl"))

--- a/src/snoopi_tree_demos.jl
+++ b/src/snoopi_tree_demos.jl
@@ -23,7 +23,7 @@ Then it collects and returns inference data using
 
 ```julia
 cc1, cc2 = [Any[0x01]], [Any[1.0]]
-@snoopi_deep ItrigDemo.calleach([cc1, cc2])
+@snoopi_tree ItrigDemo.calleach([cc1, cc2])
 ```
 
 This does not require any new inference for `calldouble2` or `calldouble1`, but it does force inference on `double` with two new types.
@@ -43,7 +43,7 @@ function itrigs_demo()
     Base.invokelatest(ItrigDemo.calleach, [cc,cc])
     # Now use UInt8 & Float64 elements to force inference on double, without forcing new inference on its callers
     cc1, cc2 = [Any[0x01]], [Any[1.0]]
-    return @snoopi_deep Base.invokelatest(ItrigDemo.calleach, [cc1, cc2])
+    return @snoopi_tree Base.invokelatest(ItrigDemo.calleach, [cc1, cc2])
 end
 
 """
@@ -78,7 +78,7 @@ ItrigHigherOrderDemo.callmymap(Any[1, 2])
 Then it collects and returns inference data using
 
 ```julia
-@snoopi_deep ItrigHigherOrderDemo.callmymap(Any[1.0, 2.0])
+@snoopi_tree ItrigHigherOrderDemo.callmymap(Any[1.0, 2.0])
 ```
 
 which forces inference for `double(::Float64)`.
@@ -103,6 +103,6 @@ function itrigs_higherorder_demo()
     #    `mymap!(::typeof(double), ::Vector{Any}, ::Vector{Any})` and `double(::Int)`
     Base.invokelatest(ItrigHigherOrderDemo.callmymap, Any[1, 2])
     src = Any[1.0, 2.0]   # double not yet inferred for Float64
-    return @snoopi_deep Base.invokelatest(ItrigHigherOrderDemo.callmymap, src)
+    return @snoopi_tree Base.invokelatest(ItrigHigherOrderDemo.callmymap, src)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,8 @@ if VERSION >= v"1.2.0-DEV.573"
 end
 
 if VERSION >= v"1.6.0-DEV.1190"  # https://github.com/JuliaLang/julia/pull/37749
-    @testset "snoopi_deep" begin
-        include("snoopi_deep.jl")
+    @testset "snoopi_tree" begin
+        include("snoopi_tree.jl")
     end
 end
 


### PR DESCRIPTION
I don't think this is a big win, but "deep" seems pretty nonspecific.
I personally find "tree" to be more descriptive of what you get back
from this macro.

But I'm happy to close this without merging if others are attached to "deep."

EDIT: maybe the "deep" here is in reference to `deepcopy`? I hadn't actually made that connection, so maybe the original is fine as is. Let's see if others chime in with thoughts on the matter.