### PR TITLE
snoopi_deep: return inclusive & exclusive times

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,6 @@ YAML = "0.4"
 julia = "1"
 
 [extras]
-AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
@@ -35,4 +34,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AbstractTrees", "ColorTypes", "Documenter", "FixedPointNumbers", "MethodAnalysis", "Pkg", "Random", "Test"]
+test = ["ColorTypes", "Documenter", "FixedPointNumbers", "MethodAnalysis", "Pkg", "Random", "Test"]

--- a/SnoopCompileCore/src/snoopi_deep.jl
+++ b/SnoopCompileCore/src/snoopi_deep.jl
@@ -3,7 +3,17 @@ struct InferenceTiming
     inclusive_time::Float64
     exclusive_time::Float64
 end
+"""
+    inclusive(frame)
+
+Return the time spent inferring `frame` and its callees.
+"""
 inclusive(it::InferenceTiming) = it.inclusive_time
+"""
+    exclusive(frame)
+
+Return the time spent inferring `frame`, not including the time needed for any of its callees.
+"""
 exclusive(it::InferenceTiming) = it.exclusive_time
 
 struct InferenceTimingNode
@@ -49,41 +59,36 @@ function _snoopi_deep(cmd::Expr)
 end
 
 """
-    timing_tree = @snoopi_deep commands
+    tinf = @snoopi_deep commands
 
-Produce a profile of julia's type inference, containing the amount of time spent inferring
-every `MethodInstance` processed while executing `commands`.
+Produce a profile of julia's type inference, recording the amount of time spent inferring
+every `MethodInstance` processed while executing `commands`. Each fresh entrance to
+type inference (whether executed directly in `commands` or because a call was made
+by runtime-dispatch) also collects a backtrace so the caller can be identified.
 
-The top-level node in this profile tree is `ROOT`, which contains the time spent _not_ in
-julia's type inference (codegen, llvm_opt, runtime, etc).
+`tinf` is a tree, each node containing data on a particular inference "frame" (the method,
+argument-type specializations, parameters, and even any constant-propagated values).
+Each reports the [`exclusive`](@ref)/[`inclusive`](@ref) times, where the exclusive
+time corresponds to the time spent inferring this frame in and of itself, whereas
+the inclusive time includes the time needed to infer all the callees of this frame.
 
-To make use of these results, see the processing functions in SnoopCompile:
-    - [`SnoopCompile.flatten(timing_tree)`](@ref)
-    - [`SnoopCompile.flamegraph(timing_tree)`](@ref)
+The top-level node in this profile tree is `ROOT`. Uniquely, its exclusive time
+corresponds to the time spent _not_ in julia's type inference (codegen, llvm_opt, runtime, etc).
 
-# Examples
-```julia
-julia> timing = @snoopi_deep begin
-           @eval sort(rand(100))  # Evaluate some code and profile julia's type inference
-       end;
+There are many different ways of inspecting and using the data stored in `tinf`.
+The simplest is to load the `AbstracTrees` package and display the tree with
+`AbstractTrees.print_tree(tinf)`.
+See also:  [`flamegraph`](@ref), [`flatten`](@ref), [`inference_triggers`](@ref), [`SnoopCompile.parcel`](@ref),
+[`runtime_inferencetime`](@ref).
 
-julia> using SnoopCompile, ProfileView
-
-julia> times = flatten(timing, tmin=0.001)
-4-element Vector{Any}:
- 0.001088448 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for fpsort!(...
- 0.001618478 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for rand!(...
- 0.002289655 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for _rand_max383!(...
- 0.093143594 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for ROOT(), ...
-
-julia> fg = flamegraph(timing)
-Node(FlameGraphs.NodeData(ROOT() at typeinfer.jl:70, 0x00, 0:15355670))
-
-julia> ProfileView.view(fg);  # Display the FlameGraph in a package that supports it
-
-julia> fg = flamegraph(timing; tmin=0.0001)  # Skip very tiny frames
-Node(FlameGraphs.NodeData(ROOT() at typeinfer.jl:70, 0x00, 0:15355670))
+# Example
+```jldoctest; setup=:(using SnoopCompile), filter=r"([0-9\\.e-]+/[0-9\\.e-]+|\\d direct)"
+julia> tinf = @snoopi_deep begin
+           sort(rand(100))  # Evaluate some code and profile julia's type inference
+       end
+InferenceTimingNode: 0.110018224/0.131464476 on InferenceFrameInfo for Core.Compiler.Timings.ROOT() with 2 direct children
 ```
+
 """
 macro snoopi_deep(cmd)
     return _snoopi_deep(cmd)

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -36,7 +36,7 @@ you should prefer them above the more limited tools available on earlier version
 
 - `@snoopi_deep`: record more extensive data about type-inference (`parcel` and `write` work on these data, too)
 - `flamegraph`: prepare a visualization from `@snoopi_deep`
-- `flatten_times`: reduce the tree format recorded by `@snoopi_deep` to list format
+- `flatten`: reduce the tree format recorded by `@snoopi_deep` to list format
 - `accumulate_by_source`: aggregate list items by their source
 - `inference_triggers`: extract data on the triggers of inference
 - `callerinstance`, `callingframe`, `skiphigherorder`, and `InferenceTrigger`: manipulate stack frames from `inference_triggers`
@@ -73,7 +73,7 @@ end
 if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
     include("parcel_snoopi_deep.jl")
     include("deep_demos.jl")
-    export @snoopi_deep, InclusiveTiming, flamegraph, flatten_times, accumulate_by_source, runtime_inferencetime
+    export @snoopi_deep, exclusive, inclusive, flamegraph, flatten, accumulate_by_source, runtime_inferencetime
     export InferenceTrigger, inference_triggers, callerinstance, callingframe, skiphigherorder
 end
 

--- a/src/deep_demos.jl
+++ b/src/deep_demos.jl
@@ -1,4 +1,55 @@
 """
+    tinf = SnoopCompile.flatten_demo()
+
+A simple demonstration of [`@snoopi_deep`](@ref). This demo defines a module
+
+```julia
+module FlattenDemo
+    struct MyType{T} x::T end
+    extract(y::MyType) = y.x
+    function packintype(x)
+        y = MyType{Int}(x)
+        return dostuff(y)
+    end
+    function domath(x)
+        y = x + x
+        return y*x + 2*x + 5
+    end
+    dostuff(y) = domath(extract(y))
+end
+```
+
+It then "warms up" (forces inference on) all of Julia's `Base` methods needed for `domath`,
+to ensure that these MethodInstances do not need to be inferred when we collect the data.
+It then returns the results of
+
+```julia
+@snoopi_deep FlattenDemo.packintypes(1)
+```
+
+See [`flatten`](@ref) for an example usage.
+"""
+function flatten_demo()
+    eval(:(
+        module FlattenDemo
+        struct MyType{T} x::T end
+        extract(y::MyType) = y.x
+        function packintype(x)
+            y = MyType{Int}(x)
+            return dostuff(y)
+        end
+        function domath(x)
+            y = x + x
+            return y*x + 2*x + 5
+        end
+        dostuff(y) = domath(extract(y))
+        end
+    ))
+    z = (1 + 1)*1 + 2*1 + 5
+    return @snoopi_deep Base.invokelatest(FlattenDemo.packintype, 1)
+end
+
+"""
     tinf = SnoopCompile.itrigs_demo()
 
 A simple demonstration of collecting inference triggers. This demo defines a module


### PR DESCRIPTION
This modifies `@snoopi_deep` to return "normalized" data that allows all analyses to have access to both inclusive and exclusive time. It also converts all times to `secs::Float64`. Finally, it does a full refresh on all the docstrings to account for the changes in results and their display.
    
Supersedes and closes #180. Other than #190 and the documenter docs, this is the last change I expect before the big release.

CC @Sacha0.
