### PR TITLE
PGDO: lookup only self time

### DIFF
--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -336,7 +336,7 @@ end
     tr, ti, nspec = rit[findfirst(pr -> pr.first == m, rit)].second
     @test ti > tr
     @test nspec >= length(Ts)
-    # specialization_plot(axs[1], rit; interactive=false)
+    # specialization_plot(axs[1], rit; bystr="Inclusive", consts=true, interactive=false)
 
     Profile.clear()
     @profile for i = 1:nruns
@@ -347,5 +347,5 @@ end
     tr, ti, nspec = rit[findfirst(pr -> pr.first == m, rit)].second
     @test ti < tr
     @test nspec == 1
-    # specialization_plot(axs[2], rit; interactive=false)
+    # specialization_plot(axs[2], rit; bystr="Inclusive", consts=true, interactive=false)
 end


### PR DESCRIPTION
Long runs can take a long time to do instruction-pointer lookup.
However, since we only credit the "self" time there is no need to
look up everything. This limits the lookup to the triggering instruction
pointer. It also attributes the cost to the whole "inlining chain."