### PR TITLE
Rename sanity-checker to `staleinstances`

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -33,6 +33,7 @@ exclusive
 inclusive
 accumulate_by_source
 collect_for
+staleinstances
 inference_triggers
 trigger_tree
 suggest

--- a/docs/src/snoopi_deep.md
+++ b/docs/src/snoopi_deep.md
@@ -61,8 +61,6 @@ This may not look like much, but there's a wealth of information hidden inside `
 
 ## A quick check for potential invalidations
 
-!!! warning
-    The presence of rampant invalidations in the MethodInstances returned by `tinf` can make some of the other analyses quite confusing. Hence, users of `@snoopi_deep` are advised to check for invalidations before performing detailed analysis or generating precompile directives.
 
 After running `@snoopi_deep`, it's generally recommended to check the output of [`staleinstances`](@ref):
 ```julia
@@ -72,6 +70,9 @@ SnoopCompileCore.InferenceTiming[]
 
 If you see this, all's well.
 A non-empty list might indicate method invalidations, which can be checked (in a fresh session) by running the identical workload with [`@snoopr`](@ref).
+
+!!! warning
+    Rampant invalidation can make the process of analyzing `tinf` more confusing: "why am I getting reinference of this `MethodInstance` when I `precompile`d it?" Routine use of `staleinstances` at the beginning can save you some head-scratching later.
 
 !!! tip
     Your workload may load packages and/or (re)define methods; these can be sources of invalidation and therefore non-empty output

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -75,7 +75,7 @@ end
 if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
     include("parcel_snoopi_deep.jl")
     include("deep_demos.jl")
-    export @snoopi_deep, exclusive, inclusive, flamegraph, flatten, accumulate_by_source, collect_for, runtime_inferencetime, invalidations
+    export @snoopi_deep, exclusive, inclusive, flamegraph, flatten, accumulate_by_source, collect_for, runtime_inferencetime, staleinstances
     export InferenceTrigger, inference_triggers, callerinstance, callingframe, skiphigherorder, trigger_tree, suggest, isignorable
 end
 


### PR DESCRIPTION
This is a more accurate description of what it does, and therefore
is less likely to cause confusion. This also reworks the implementation
to make it easier to run the core logic on either MethodInstances or
InferenceTimingNodes.