### PR TITLE
Fix indentation in uinvalidated docstring

### DIFF
--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -10,7 +10,7 @@ function from_corecompiler(mi::MethodInstance)
 end
 
 """
-   umis = uinvalidated(invlist)
+    umis = uinvalidated(invlist)
 
 Return the unique invalidated MethodInstances. `invlist` is obtained from [`SnoopCompileCore.@snoopr`](@ref).
 This is similar to `filter`ing for `MethodInstance`s in `invlist`, except that it discards any tagged


### PR DESCRIPTION
BTW, I'm not sure why the `umis =` part is there (the docstring doesn't refer to it).