### PR TITLE
Fix a Union-handling bug in `hascorebox`

### DIFF
--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -1527,11 +1527,11 @@ function hascorebox(@nospecialize(typ))
     typ = unwrapconst(typ)
     isa(typ, Type) || return false
     typ === Core.Box && return true
+    typ = Base.unwrap_unionall(typ)
+    typ === Union{} && return false
     if isa(typ, Union)
         return hascorebox(typ.a) | hascorebox(typ.b)
     end
-    typ = Base.unwrap_unionall(typ)
-    typ === Union{} && return false
     for p in typ.parameters
         hascorebox(p) && return true
     end

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -511,6 +511,7 @@ end
     @test occursin(r"error path.*ignore", String(take!(io)))
 
     # Core.Box
+    @test !SnoopCompile.hascorebox(AbstractVecOrMat{T} where T)   # test Union handling
     @eval module M
         struct MyInt <: Integer end
         Base.:(*)(::MyInt, r::Int) = 7*r

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -356,6 +356,15 @@ end
     SnoopCompile.show_suggest(io, cats, nothing, nothing)
     @test occursin(r"invoked callee.*may fail to precompile", String(take!(io)))
 
+    # FromInvokeLatest
+    @eval module M
+        f(::Int) = 1
+        g(x) = Base.invokelatest(f, x)
+    end
+    cats = categories(@snoopi_deep M.g(3))
+    @test SnoopCompile.FromInvokeLatest ∈ cats
+    @test isignorable(cats[1])
+
     # CalleeVariable
     mysin(x) = 1
     mycos(x) = 2


### PR DESCRIPTION
This was discovered in the process of putting together the demo in https://github.com/aviatesk/JET.jl/issues/105. JET is an interesting comparison for this package because in principle it's more thorough than SnoopCompile, so it would be great to get both packages to the point where they can be compared.