### PR TITLE
Add `@snoopl` to reference docs

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -7,6 +7,7 @@
 @snoopi_deep
 @snoopi
 @snoopc
+@snoopl
 ```
 
 ## GUIs
@@ -51,6 +52,7 @@ SnoopCompile.write
 
 ```@docs
 SnoopCompile.read
+SnoopCompile.read_snoopl
 SnoopCompile.format_userimg
 ```
 


### PR DESCRIPTION
I just noticed that `@snoopl` isn't in the documentation at all. I know it's not very widely used, but it'd be nice to refer to it here at least. :)

`@snoopl` was originally added in https://github.com/timholy/SnoopCompile.jl/pull/135/.