### PR TITLE
Suggest only if the callee matches the trigger

### DIFF
--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -1446,6 +1446,7 @@ function suggest(itrig::InferenceTrigger)
                         push!(s.categories, CalleeVariable)
                     end
                     if isa(calleef, Function)
+                        nameof(calleef) == rtcalleename || continue
                         # if isa(argtyps, Core.Argument)
                         #     argtyps = unwrapconst(ct.slottypes[argtyps.n])
                         # elseif isa(argtyps, Core.SSAValue)


### PR DESCRIPTION
The issue here is a call to

    hvcat(rows::Tuple{Vararg{Int}}, xs::_DenseConcatGroup...) = Base.typed_hvcat(promote_eltype(xs...), rows, xs...)

which has a couple of `Core._apply_iterate` and the matching fails
when it doesn't match the trigger `promote_eltype`.
I tried to come up with a MWE but failed.

Fixes #244