### PR TITLE
Fix tree construction with method overwriting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompile"
 uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "2.7.0"
+version = "2.7.1"
 
 [deps]
 Cthulhu = "f68482b8-f384-11e8-15f7-abe071a5a75f"
@@ -21,7 +21,7 @@ Cthulhu = "1.5, 2"
 FlameGraphs = "0.2"
 OrderedCollections = "1"
 Requires = "1"
-SnoopCompileCore = "~2.7.0"
+SnoopCompileCore = "~2.7.1"
 YAML = "0.4"
 julia = "1"
 

--- a/SnoopCompileCore/Project.toml
+++ b/SnoopCompileCore/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompileCore"
 uuid = "e2b509da-e806-4183-be48-004708413034"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "2.7.0"
+version = "2.7.1"
 
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/test/colortypes.jl
+++ b/test/colortypes.jl
@@ -5,6 +5,7 @@ using SnoopCompile, Test, Pkg
     @test success
     @test modsym == :ColorTypes
 
+    @info "Beginning @snoopc test on ColorTypes. Note failures in ColorTypes' tests do not count as failures here."
     mktempdir() do tmpdir
         tmpfile = joinpath(tmpdir, "colortypes_compiles.csv")
         tmpdir2 = joinpath(tmpdir, "precompile")


### PR DESCRIPTION
Fixes `MethodError: no method matching getroot(::Nothing)` when constructing invalidation trees from certain patterns. Detected with packages in an intermediate state in the refactoring around IrrationalConstants.jl of StatsFuns.jl and LogExpFunctions.jl.

CC @ChrisRackauckas 