### PR TITLE
Make InferenceTimingNode bidirectional

### DIFF
--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -25,6 +25,8 @@ isROOT(m::Method) = m === Core.Compiler.Timings.ROOTmi.def
 isROOT(mi_info::InferenceNode) = isROOT(MethodInstance(mi_info))
 isROOT(node::InferenceTimingNode) = isROOT(node.mi_timing)
 
+getroot(node::InferenceTimingNode) = isdefined(node.parent, :parent) ? getroot(node.parent) : node
+
 # Record instruction pointers we've already looked up (performance optimization)
 const lookups = Dict{Union{UInt, Core.Compiler.InterpreterIP}, Vector{StackTraces.StackFrame}}()
 lookups_key(ip) = ip

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -38,6 +38,9 @@ hasconstpropnumber(mi_info::Core.Compiler.Timings.InferenceFrameInfo) = any(t ->
     end
     @test SnoopCompile.isROOT(Core.MethodInstance(tinf))
     @test SnoopCompile.isROOT(Method(tinf))
+    child = tinf.children[1]
+    @test SnoopCompile.getroot(child.children[1]) == child
+    @test SnoopCompile.getroot(child.children[1].children[1].children[1]) == child
     @test isempty(staleinstances(tinf))
     frames = filter(!hasconstpropnumber, flatten(tinf))
     @test length(frames) == 7  # ROOT, g(::Int), g(::Bool), h(...), i(::Integer), i(::Int), i(::Bool)


### PR DESCRIPTION
It's often convenient to be able to easily find the parent.