### PR TITLE
Track invalidations during deserialization

### DIFF
--- a/test/testmodules/Stale/Project.toml
+++ b/test/testmodules/Stale/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+StaleA = "daf834c3-b832-4a67-a95b-01ec1ffe9b4d"
+StaleB = "af730a9e-e668-4d07-a0f0-de54196c2067"
+StaleC = "f6b5ece7-60fa-49fc-ba7e-b783050e37f1"

--- a/test/testmodules/Stale/StaleA/Project.toml
+++ b/test/testmodules/Stale/StaleA/Project.toml
@@ -1,0 +1,4 @@
+name = "StaleA"
+uuid = "daf834c3-b832-4a67-a95b-01ec1ffe9b4d"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"

--- a/test/testmodules/Stale/StaleA/src/StaleA.jl
+++ b/test/testmodules/Stale/StaleA/src/StaleA.jl
@@ -1,0 +1,15 @@
+module StaleA
+
+stale(x) = rand(1:8)
+stale(x::Int) = length(digits(x))
+
+not_stale(x::String) = first(x)
+
+use_stale(c) = stale(c[1]) + not_stale("hello")
+build_stale(x) = use_stale(Any[x])
+
+# force precompilation
+build_stale(37)
+stale('c')
+
+end

--- a/test/testmodules/Stale/StaleB/Project.toml
+++ b/test/testmodules/Stale/StaleB/Project.toml
@@ -1,0 +1,8 @@
+name = "StaleB"
+uuid = "af730a9e-e668-4d07-a0f0-de54196c2067"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+StaleA = "daf834c3-b832-4a67-a95b-01ec1ffe9b4d"
+StaleC = "f6b5ece7-60fa-49fc-ba7e-b783050e37f1"

--- a/test/testmodules/Stale/StaleB/src/StaleB.jl
+++ b/test/testmodules/Stale/StaleB/src/StaleB.jl
@@ -1,0 +1,14 @@
+module StaleB
+
+# StaleB does not know about StaleC when it is being built.
+# However, if StaleC is loaded first, we get `"insert_backedges"`
+# invalidations.
+using StaleA
+
+# This will be invalidated if StaleC is loaded
+useA() = StaleA.stale("hello")
+
+# force precompilation
+useA()
+
+end

--- a/test/testmodules/Stale/StaleC/Project.toml
+++ b/test/testmodules/Stale/StaleC/Project.toml
@@ -1,0 +1,7 @@
+name = "StaleC"
+uuid = "f6b5ece7-60fa-49fc-ba7e-b783050e37f1"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+StaleA = "daf834c3-b832-4a67-a95b-01ec1ffe9b4d"

--- a/test/testmodules/Stale/StaleC/src/StaleC.jl
+++ b/test/testmodules/Stale/StaleC/src/StaleC.jl
@@ -1,0 +1,10 @@
+module StaleC
+
+using StaleA
+
+StaleA.stale(x::String) = length(x)
+call_buildstale(x) = StaleA.build_stale(x)
+
+call_buildstale("hey")
+
+end # module


### PR DESCRIPTION
These were printed to the console but not otherwise stored.
Storing them allows one to give them more emphasis and perform
analysis. With https://github.com/JuliaLang/julia/pull/41913,
it becomes possible to attribute them to specific method
definitions or deletions. (Of course there might be multiple
reasons, but we need to identify at least one in order to make
progress.)

CC @chriselrod, @vtjnash, @ChrisRackauckas. If anyone plans to try this, until 2.8 is released be sure to `dev SnoopCompileCore` too as it is a separate (subdir) module and there are changes due to #257.