### PR TITLE
Improve attribution of delayed invalidations

### DIFF
--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -786,10 +786,7 @@ end
     if Base.VERSION >= v"1.8.0-DEV.368"
         cproj = Base.active_project()
         cd(joinpath("testmodules", "Stale")) do
-            @show pwd()
             Pkg.activate(pwd())
-            Pkg.status()
-            Pkg.instantiate()
             Pkg.precompile()
         end
         invalidations = @snoopr begin

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -789,6 +789,7 @@ end
             @show pwd()
             Pkg.activate(pwd())
             Pkg.status()
+            Pkg.instantiate()
             Pkg.precompile()
         end
         invalidations = @snoopr begin

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -788,6 +788,7 @@ end
         cd(joinpath("testmodules", "Stale")) do
             @show pwd
             Pkg.activate(pwd())
+            Pkg.status()
             Pkg.precompile()
         end
         invalidations = @snoopr begin

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -786,7 +786,7 @@ end
     if Base.VERSION >= v"1.8.0-DEV.368"
         cproj = Base.active_project()
         cd(joinpath("testmodules", "Stale")) do
-            @show pwd
+            @show pwd()
             Pkg.activate(pwd())
             Pkg.status()
             Pkg.precompile()

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -786,6 +786,7 @@ end
     if Base.VERSION >= v"1.8.0-DEV.368"
         cproj = Base.active_project()
         cd(joinpath("testmodules", "Stale")) do
+            @show pwd
             Pkg.activate(pwd())
             Pkg.precompile()
         end

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -249,5 +249,13 @@ end
         @test mi1 == callee
         @test mi2 == caller
         @test Core.MethodInstance(tree.backedges[1]) == callee
+        io = IOBuffer()
+        print(io, tree)
+        str = String(take!(io))
+        @test occursin(r"fake1\(x\) in.*formerly fake1\(x\) in", str)
+        Base.delete_method(callee.def)
+        print(io, tree)
+        str = String(take!(io))
+        @test occursin(r"\(unavailable\).*formerly fake1\(x\) in", str)
     end
 end

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -221,14 +221,17 @@ end
         M = @eval Module() begin
             fake1(x) = 1
             fake2(x) = fake1(x)
+            fake3() = nothing
             foo() = nothing
             @__MODULE__
         end
         M.fake2('a')
+        M.fake3()
         callee = methodinstance(M.fake1, (Char,))
         caller = methodinstance(M.fake2, (Char,))
+        othercallee = methodinstance(M.fake3, ())
         # failed attribution (no invalidations occurred prior to the backedges invalidations)
-        invalidations = Any[callee, "insert_backedges_callee", caller, "insert_backedges"]
+        invalidations = Any[callee, "insert_backedges_callee", othercallee, "insert_backedges_callee", caller, "insert_backedges"]
         pipe = Pipe()
         redirect_stdout(pipe) do
             @test_logs (:warn, "Could not attribute the following delayed invalidations:") begin

--- a/test/testmodules/Stale/Manifest.toml
+++ b/test/testmodules/Stale/Manifest.toml
@@ -1,0 +1,21 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.6.3-pre.1"
+manifest_format = "2.0"
+
+[[deps.StaleA]]
+path = "StaleA"
+uuid = "daf834c3-b832-4a67-a95b-01ec1ffe9b4d"
+version = "0.1.0"
+
+[[deps.StaleB]]
+deps = ["StaleA", "StaleC"]
+path = "StaleB"
+uuid = "af730a9e-e668-4d07-a0f0-de54196c2067"
+version = "0.1.0"
+
+[[deps.StaleC]]
+deps = ["StaleA"]
+path = "StaleC"
+uuid = "f6b5ece7-60fa-49fc-ba7e-b783050e37f1"
+version = "0.1.0"


### PR DESCRIPTION
Improves on #260 by collecting all callees and callers and then doing
the attribution at once (finding at least one identifiable callee).