### PR TITLE
Identify invalidating blockers of precompilation

### DIFF
--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -106,6 +106,11 @@ if isdefined(SnoopCompileCore, Symbol("@snoopr"))
     export @snoopr, uinvalidated, invalidation_trees, filtermod, findcaller, ascend
 end
 
+if isdefined(SnoopCompileCore, Symbol("@snoopr")) && isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
+    include("invalidation_and_inference.jl")
+    export precompile_blockers
+end
+
 # Write
 include("write.jl")
 

--- a/src/invalidation_and_inference.jl
+++ b/src/invalidation_and_inference.jl
@@ -1,0 +1,136 @@
+# Combining invalidation and snoopi_deep data
+
+struct StaleTree
+    method::Method
+    reason::Symbol   # :inserting or :deleting
+    mt_backedges::Vector{Tuple{Any,Union{InstanceNode,MethodInstance},Vector{InferenceTimingNode}}}   # sig=>root
+    backedges::Vector{Tuple{InstanceNode,Vector{InferenceTimingNode}}}
+end
+StaleTree(method::Method, reason) = StaleTree(method, reason, staletree_storage()...)
+StaleTree(tree::MethodInvalidations) = StaleTree(tree.method, tree.reason)
+
+staletree_storage() = (
+    Tuple{Any,Union{InstanceNode,MethodInstance},Vector{InferenceTimingNode}}[],
+    Tuple{InstanceNode,Vector{InferenceTimingNode}}[])
+
+function Base.show(io::IO, tree::StaleTree)
+    iscompact = get(io, :compact, false)::Bool
+
+    print(io, tree.reason, " ")
+    printstyled(io, tree.method, color = :light_magenta)
+    println(io, " invalidated:")
+    indent = iscompact ? "" : "   "
+
+    if !isempty(tree.mt_backedges)
+        print(io, indent, "mt_backedges: ")
+        showlist(io, tree.mt_backedges, length(indent)+length("mt_backedges")+2)
+    end
+    if !isempty(tree.backedges)
+        print(io, indent, "backedges: ")
+        showlist(io, tree.backedges, length(indent)+length("backedges")+2)
+    end
+    iscompact && print(io, ';')
+end
+
+function printdata(io, tnodes::AbstractVector{InferenceTimingNode})
+    print(io, " (")
+    if length(tnodes) == 1
+        print(io, tnodes[1])
+    else
+        print(io, sum(inclusive, tnodes), " inclusive time")
+    end
+    print(io, ")")
+end
+
+
+
+
+precompile_blockers(invalidations, tinf::InferenceTimingNode) =
+    precompile_blockers(invalidation_trees(invalidations)::Vector{MethodInvalidations}, tinf)
+
+"""
+    staletrees = precompile_blockers(invalidations, tinf::InferenceTimingNode)
+
+Select just those invalidations that contribute to "stale nodes" in `tinf`, and link them together.
+This can allow one to identify specific blockers of precompilation for particular MethodInstances.
+
+# Example
+
+```julia
+using SnoopCompileCore
+invalidations = @snoopr using PkgA, PkgB;
+using SnoopCompile
+trees = invalidation_trees(invalidations)
+tinf = @snoopi_deep begin
+    some_workload()
+end
+staletrees = precompile_blockers(trees, tinf)
+```
+"""
+function precompile_blockers(trees::Vector{MethodInvalidations}, tinf::InferenceTimingNode)
+    sig2node = nodedict!(IdDict{Type,InferenceTimingNode}(), tinf)
+    snodes = stalenodes(tinf)
+    mi2stalenode = Dict(MethodInstance(node) => i for (i, node) in enumerate(snodes))
+    # Prepare "thinned trees" focusing just on those invalidations that blocked precompilation
+    staletrees = StaleTree[]
+    for tree in trees
+        mt_backedges, backedges = staletree_storage()
+        for (sig, root) in tree.mt_backedges
+            triggers = Set{MethodInstance}()
+            thinned = filterbranch(node -> haskey(mi2stalenode, convert(MethodInstance, node)), root, triggers)
+            if thinned !== nothing
+                push!(mt_backedges, (sig, thinned, [snodes[mi2stalenode[mi]] for mi in triggers]))
+            end
+        end
+        for root in tree.backedges
+            triggers = Set{MethodInstance}()
+            thinned = filterbranch(node -> haskey(mi2stalenode, convert(MethodInstance, node)), root, triggers)
+            if thinned !== nothing
+                push!(backedges, (thinned, [snodes[mi2stalenode[mi]] for mi in triggers]))
+            end
+        end
+        if !isempty(mt_backedges) || !isempty(backedges)
+            sort!(mt_backedges; by=suminclusive)
+            sort!(backedges; by=suminclusive)
+            push!(staletrees, StaleTree(tree.method, tree.reason, mt_backedges, backedges))
+        end
+    end
+    # # Associate each root with one or more snodes
+    # staletrees = StaleTree[]
+    # for (i, tree) in enumerate(pctrees)
+    #     staletree = StaleTree(tree)
+    #     for (sig, root) in tree.mt_backedges
+    #         for leaf in PreOrderDFS(root)
+    #             mi = MethodInstance(leaf)
+    #             if haskey(smis, mi)
+    #                 push!(staletree.mt_backedges, (sig, root, snodes[smis[mi]]))
+    #             end
+    #         end
+    #     end
+    #     if !isempty(mt_backedges) || !isempty(backedges) || !isempty(pre_invalidated)
+    #         sort!(pre_invalidated; by=inclusive ∘ last)
+    #         sort!(mt_backedges; by=suminclusive)
+    #         sort!(backedges; by=suminclusive)
+    #         push!(staletrees, StaleTree(tree.method, tree.reason, mt_backedges, backedges, pre_invalidated))
+    #     end
+    # end
+    sort!(staletrees; by=inclusive)
+    return staletrees
+end
+
+function nodedict!(d, tinf::InferenceTimingNode)
+    for child in tinf.children
+        sig = MethodInstance(child).specTypes
+        oldinf = get(d, sig, nothing)
+        if oldinf === nothing || inclusive(child) > inclusive(oldinf)
+            d[sig] = child
+        end
+        nodedict!(d, child)
+    end
+    return d
+end
+
+suminclusive(t::Tuple) = sum(inclusive, last(t))
+SnoopCompileCore.inclusive(tree::StaleTree) =
+    sum(suminclusive, tree.mt_backedges; init=0.0) +
+    sum(suminclusive, tree.backedges; init=0.0)

--- a/src/invalidation_and_inference.jl
+++ b/src/invalidation_and_inference.jl
@@ -59,9 +59,9 @@ end
 staletrees = precompile_blockers(trees, tinf)
 ```
 """
-function precompile_blockers(trees::Vector{MethodInvalidations}, tinf::InferenceTimingNode)
+function precompile_blockers(trees::Vector{MethodInvalidations}, tinf::InferenceTimingNode; kwargs...)
     sig2node = nodedict!(IdDict{Type,InferenceTimingNode}(), tinf)
-    snodes = stalenodes(tinf)
+    snodes = stalenodes(tinf; kwargs...)
     mi2stalenode = Dict(MethodInstance(node) => i for (i, node) in enumerate(snodes))
     # Prepare "thinned trees" focusing just on those invalidations that blocked precompilation
     staletrees = StaleTree[]
@@ -91,8 +91,8 @@ function precompile_blockers(trees::Vector{MethodInvalidations}, tinf::Inference
     return staletrees
 end
 
-precompile_blockers(invalidations, tinf::InferenceTimingNode) =
-    precompile_blockers(invalidation_trees(invalidations)::Vector{MethodInvalidations}, tinf)
+precompile_blockers(invalidations, tinf::InferenceTimingNode; kwargs...) =
+    precompile_blockers(invalidation_trees(invalidations)::Vector{MethodInvalidations}, tinf; kwargs...)
 
 
 function nodedict!(d, tinf::InferenceTimingNode)

--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -224,7 +224,7 @@ function showlist(io::IO, treelist, indent::Int=0)
         elseif isa(root, Tuple)
             printstyled(io, root[end-1], color = :light_yellow)
             print(io, " blocked ")
-            show(IOContext(io, :typeinfo=>InferenceTimingNode), root[end])
+            printdata(io, root[end])
             root = nothing
         else
             print(io, "superseding ")
@@ -364,7 +364,7 @@ function invalidation_trees(list; exclude_corecompiler::Bool=true)
                 elseif loctag == "insert_backedges"
                     # pre Julia 1.8
                     println("insert_backedges for ", mi)
-                    Base.VERSION < v"1.8.0-DEV" || error("unexpected failure at ", i)
+                    Base.VERSION < v"1.8.0-DEV.368" || error("unexpected failure at ", i)
                     @assert leaf === nothing
                 else
                     error("unexpected loctag ", loctag, " at ", i)
@@ -470,7 +470,8 @@ function filtermod(mod::Module, trees::AbstractVector{MethodInvalidations}; kwar
     return sort!(thinned; by=countchildren)
 end
 
-hasmod(mod::Module, node::InstanceNode) = node.mi.def.module === mod
+hasmod(mod::Module, node::InstanceNode) = hasmod(mod, MethodInstance(node))
+hasmod(mod::Module, mi::MethodInstance) = mi.def.module === mod
 
 function filtermod(mod::Module, methinvs::MethodInvalidations; recursive::Bool=false)
     if recursive

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -826,8 +826,13 @@ end
         @test root == Core.MethodInstance(only(hits)) == methodinstance(StaleB.useA, ())
         # What happens when we can't find it in the tree?
         idx = findfirst(isequal("jl_method_table_insert"), invalidations)
-        broken_trees = invalidation_trees(invalidations[idx+1:end])
-        @test isempty(precompile_blockers(broken_trees, tinf))
+        pipe = Pipe()
+        redirect_stdout(pipe) do
+            @test_logs (:warn, "Could not attribute the following delayed invalidations:") begin
+                broken_trees = invalidation_trees(invalidations[idx+1:end])
+                @test isempty(precompile_blockers(broken_trees, tinf))
+            end
+        end
         # IO
         io = IOBuffer()
         print(io, trees)

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -40,6 +40,7 @@ hasconstpropnumber(mi_info::Core.Compiler.Timings.InferenceFrameInfo) = any(t ->
     @test SnoopCompile.isROOT(Core.MethodInstance(tinf))
     @test SnoopCompile.isROOT(Method(tinf))
     child = tinf.children[1]
+    @test convert(SnoopCompile.InferenceTiming, child).inclusive_time > 0
     @test SnoopCompile.getroot(child.children[1]) == child
     @test SnoopCompile.getroot(child.children[1].children[1]) == child
     @test isempty(staleinstances(tinf))
@@ -817,11 +818,32 @@ end
         root, hits = only(tree.backedges)
         @test Core.MethodInstance(root).def == which(StaleA.stale, (Any,))
         @test Core.MethodInstance(only(hits)).def == which(StaleA.use_stale, (Vector{Any},))
+        # If we don't discount ones left in an invalidated state,
+        # we get mt_backedges with a MethodInstance middle entry too
+        strees2 = precompile_blockers(invalidations, tinf; min_world_exclude=0)
+        sig, root, hits = only(only(strees2).mt_backedges)
+        @test sig == methodinstance(StaleA.stale, (String,))
+        @test root == Core.MethodInstance(only(hits)) == methodinstance(StaleB.useA, ())
+        # What happens when we can't find it in the tree?
+        idx = findfirst(isequal("jl_method_table_insert"), invalidations)
+        broken_trees = invalidation_trees(invalidations[idx+1:end])
+        @test isempty(precompile_blockers(broken_trees, tinf))
+        # IO
         io = IOBuffer()
+        print(io, trees)
+        @test occursin(r"stale\(x::String\) in StaleC.*formerly stale\(x\) in StaleA", String(take!(io)))
         print(io, strees)
         str = String(take!(io))
         @test occursin(r"inserting stale.* in StaleC.*invalidated:", str)
         @test occursin(r"blocked.*InferenceTimingNode: .*/.* on StaleA.use_stale", str)
+        @test endswith(str, "\n]")
+        print(IOContext(io, :compact=>true), strees)
+        str = String(take!(io))
+        @test endswith(str, ";]")
+        SnoopCompile.printdata(io, [hits; hits])
+        @test occursin("inclusive time for 2 nodes", String(take!(io)))
+        print(io, strees2)
+        @test occursin("mt_backedges", String(take!(io)))
     end
     Pkg.activate(cproj)
 end


### PR DESCRIPTION
This allows one to identify the particular invalidations that block
precompilation of particular MethodInstances.

I am not 100% sure this is right. In particular, it might be too conservative; maybe one should `SnoopCompile.getrroot(hits[i])` to see the real impact? But I checked whether the root CodeInstances are there in the precompile cache, and they seem to be. So my best guess is that this is painting an accurate picture as-is. I might let this sit on master for a few days before making a release. 

CC @ChrisRackauckas. It seems to suggest that invalidation is not your first-order problem with https://github.com/SciML/ModelingToolkit.jl/pull/1215, as you seemed to expect. But I wanted to get this tool out there in some form.