### PR TITLE
Update docs, v2.8.0

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: nightly
+          version: '1'
       - run: julia --project -e 'using Pkg; Pkg.develop([PackageSpec(path=joinpath(pwd(), "SnoopCompileCore"))])'
       - uses: julia-actions/julia-buildpkg@latest
       - run: julia --project=docs/ -e 'using Pkg; Pkg.develop([PackageSpec(path=joinpath(pwd(), "SnoopCompileCore"))]); Pkg.instantiate()'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompile"
 uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "2.7.1"
+version = "2.8.0"
 
 [deps]
 Cthulhu = "f68482b8-f384-11e8-15f7-abe071a5a75f"
@@ -21,7 +21,7 @@ Cthulhu = "1.5, 2"
 FlameGraphs = "0.2"
 OrderedCollections = "1"
 Requires = "1"
-SnoopCompileCore = "~2.7.1"
+SnoopCompileCore = "~2.8.0"
 YAML = "0.4"
 julia = "1"
 

--- a/SnoopCompileCore/Project.toml
+++ b/SnoopCompileCore/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompileCore"
 uuid = "e2b509da-e806-4183-be48-004708413034"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "2.7.1"
+version = "2.8.0"
 
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -84,9 +84,9 @@ For developers who can use Julia 1.6+, the recommended sequence is:
 
 1. Check for [invalidations](@ref), and if egregious make fixes before proceeding further
 2. Record inference data with [`@snoopi_deep`](@ref). Analyze the data to:
-    + adjust method specialization in your package or its dependencies
-    + fix problems in type inference
-    + add `precompile` directives
+    + adjust method specialization in your package or its dependencies (see [pgds](@ref))
+    + fix problems in [inferrability](@ref)
+    + add [precompilation](@ref)
 
 Under 2, the first two sub-points can often be done at the same time; the last item is best done as a final step, because the specific
 precompile directives needed depend on the state of your code, and a few fixes in specialization

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -22,6 +22,7 @@ pgdsgui
 ```@docs
 uinvalidated
 invalidation_trees
+precompile_blockers
 filtermod
 findcaller
 ```

--- a/docs/src/snoopi.md
+++ b/docs/src/snoopi.md
@@ -101,11 +101,14 @@ time to be discarded.
 
 !!! note
     If you're testing this, you might get different results depending on
-    the speed of your machine. Moreover, if FixedPointNumbers has already precompiled
-    these method and type combinations---perhaps by incorporating a precompile file
-    produced by SnoopCompile---then those methods will be absent.
-    If you want to try this example, `dev FixedPointNumbers` and disable any
-    `_precompile_()` call you find.
+    the speed of your machine. Moreover, if FixedPointNumbers has
+    already precompiled these method and type combinations---perhaps
+    by incorporating a precompile file produced by SnoopCompile---then
+    those methods will be absent.  For packages whose precompile
+    directives are executed only when `ccall(:jl_generating_output,
+    Cint, ()) == 1`, you can start Julia with `--compiled-modules=no`
+    to disable them.  Alternatively, you can `dev` the package and
+    comment them out.
 
 You can inspect these results and write your own precompile file, or use the automated
 tools provided by SnoopCompile.

--- a/docs/src/snoopi_deep.md
+++ b/docs/src/snoopi_deep.md
@@ -80,6 +80,8 @@ A non-empty list might indicate method invalidations, which can be checked (in a
     One trick that may circumvent some invalidation is to load the packages and make the method definitions before launching `@snoopi_deep`, because it ensures the methods are in place
     before your workload triggers compilation.
 
+If you do have a lot of invalidations, [`precompile_blockers`](@ref) may be an effective way to reveal those invalidations that affect your particular package and workload.
+
 ## Viewing the results
 
 Let's start unpacking the output of `@snoopi_deep` and see how to get more insight.

--- a/docs/src/snoopi_deep.md
+++ b/docs/src/snoopi_deep.md
@@ -49,7 +49,7 @@ To profile inference on this call, we simply do the following:
 
 ```jldoctest flatten-demo; setup=:(using SnoopCompile), filter=r"([0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?|WARNING: replacing module FlattenDemo\.\n)"
 julia> tinf = @snoopi_deep FlattenDemo.packintype(1)
-InferenceTimingNode: 0.00932195/0.010080857 on InferenceFrameInfo for Core.Compiler.Timings.ROOT() with 1 direct children
+InferenceTimingNode: 0.002712/0.003278 on Core.Compiler.Timings.ROOT() with 1 direct children
 ```
 
 !!! tip
@@ -96,14 +96,14 @@ We can do that with the [AbstractTrees](https://github.com/JuliaCollections/Abst
 julia> using AbstractTrees
 
 julia> print_tree(tinf)
-InferenceTimingNode: 0.00932195/0.0100809 on InferenceFrameInfo for Core.Compiler.Timings.ROOT() with 1 direct children
-└─ InferenceTimingNode: 0.00018625/0.000758907 on InferenceFrameInfo for FlattenDemo.packintype(::Int64) with 2 direct children
-   ├─ InferenceTimingNode: 0.000132252/0.000132252 on InferenceFrameInfo for MyType{Int64}(::Int64) with 0 direct children
-   └─ InferenceTimingNode: 0.000116106/0.000440405 on InferenceFrameInfo for FlattenDemo.dostuff(::MyType{Int64}) with 2 direct children
-      ├─ InferenceTimingNode: 8.4173e-5/0.000161672 on InferenceFrameInfo for FlattenDemo.extract(::MyType{Int64}) with 2 direct children
-      │  ├─ InferenceTimingNode: 4.3641e-5/4.3641e-5 on InferenceFrameInfo for getproperty(::MyType{Int64}, ::Symbol) with 0 direct children
-      │  └─ InferenceTimingNode: 3.3858e-5/3.3858e-5 on InferenceFrameInfo for getproperty(::MyType{Int64}, x::Symbol) with 0 direct children
-      └─ InferenceTimingNode: 0.000162627/0.000162627 on InferenceFrameInfo for FlattenDemo.domath(::Int64) with 0 direct children
+InferenceTimingNode: 0.002712/0.003278 on Core.Compiler.Timings.ROOT() with 1 direct children
+└─ InferenceTimingNode: 0.000133/0.000566 on FlattenDemo.packintype(::Int64) with 2 direct children
+   ├─ InferenceTimingNode: 0.000094/0.000094 on FlattenDemo.MyType{Int64}(::Int64) with 0 direct children
+   └─ InferenceTimingNode: 0.000089/0.000339 on FlattenDemo.dostuff(::FlattenDemo.MyType{Int64}) with 2 direct children
+      ├─ InferenceTimingNode: 0.000064/0.000122 on FlattenDemo.extract(::FlattenDemo.MyType{Int64}) with 2 direct children
+      │  ├─ InferenceTimingNode: 0.000034/0.000034 on getproperty(::FlattenDemo.MyType{Int64}, ::Symbol) with 0 direct children
+      │  └─ InferenceTimingNode: 0.000024/0.000024 on getproperty(::FlattenDemo.MyType{Int64}, x::Symbol) with 0 direct children
+      └─ InferenceTimingNode: 0.000127/0.000127 on FlattenDemo.domath(::Int64) with 0 direct children
 ```
 
 This tree structure reveals the caller-callee relationships, showing the specific types that were used for each `MethodInstance`.
@@ -118,10 +118,10 @@ You can extract the `MethodInstance` with
 
 ```jldoctest flatten-demo
 julia> Core.MethodInstance(tinf)
-MethodInstance for Core.Compiler.Timings.ROOT()
+MethodInstance for ROOT()
 
 julia> Core.MethodInstance(tinf.children[1])
-MethodInstance for FlattenDemo.packintype(::Int64)
+MethodInstance for packintype(::Int64)
 ```
 
 Each node in this tree is accompanied by a pair of numbers.

--- a/docs/src/snoopi_deep_analysis.md
+++ b/docs/src/snoopi_deep_analysis.md
@@ -1,4 +1,4 @@
-# Using `@snoopi_deep` results to improve inferrability
+# [Using `@snoopi_deep` results to improve inferrability](@id inferrability)
 
 As indicated in the [workflow](@ref), the recommended steps to reduce latency are:
 

--- a/docs/src/snoopr.md
+++ b/docs/src/snoopr.md
@@ -274,6 +274,11 @@ Again, if you're following along, it's possible that you'll see something quite 
 
 ## Filtering invalidations
 
+!!! info
+    The experimental tool [`SnoopCompile.precompile_blockers`](@ref) may be
+    able to help you identify just the invalidations you need to fix
+    for your use-case.
+
 Some method definitions trigger widespread invalidation.
 If you don't have time to fix all of them, you might want to focus on a specific set of invalidations.
 For instance, you might be the author of `PkgA` and you've noted that loading `PkgB` invalidates a lot of `PkgA`'s code.

--- a/src/invalidation_and_inference.jl
+++ b/src/invalidation_and_inference.jl
@@ -58,6 +58,12 @@ tinf = @snoopi_deep begin
 end
 staletrees = precompile_blockers(trees, tinf)
 ```
+
+In many cases, this reduces the number of invalidations that require analysis by one or more orders of magnitude.
+
+!!! info
+    `precompile_blockers` is experimental and has not yet been thoroughly vetted by real-world use.
+    Users are encouraged to try it and report any "misses" or unnecessary "hits."
 """
 function precompile_blockers(trees::Vector{MethodInvalidations}, tinf::InferenceTimingNode; kwargs...)
     sig2node = nodedict!(IdDict{Type,InferenceTimingNode}(), tinf)


### PR DESCRIPTION
This updates the documentation (the main goal was to get `precompile_blockers` in, but other fixes were made too). A more thorough "cookbook" revision of the documentation may need to wait until later.

Also bumps version to 2.8.0.