### PR TITLE
Skip nothing results in visualization to avoid log(::Nothing)

### DIFF
--- a/src/visualizations.jl
+++ b/src/visualizations.jl
@@ -37,6 +37,8 @@ function pgdsgui(ax::PyCall.PyObject, ridata::AbstractVector{Pair{Union{Method,M
 
     meths, rts, its, nspecs, ecols = Union{Method,MethodLoc}[], Float64[], Float64[], Int[], Tuple{Float64,Float64,Float64}[]
     for (m, d) in ridata  # (rt, trtd, it, nspec)
+        d.trun == nothing && continue
+        d.tinf == nothing && continue
         push!(meths, m)
         push!(rts, d.trun)
         push!(its, d.tinf)


### PR DESCRIPTION
I've been visualizing invalidations for a package, the plots and docs are fantastic. I have been running into an error when plotting, however:

```
RuntimeError: <PyCall.jlwrap (in a Julia function called from Python)
JULIA: MethodError: no method matching log(::Nothing)
Closest candidates are:
  log(!Matched::StridedMatrix{T} where T) at /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/LinearAlgebra/src/dense.jl:757
  log(!Matched::SymbolicUtils.Add) at ~/.julia/packages/SymbolicUtils/fgHzN/src/methods.jl:68
  log(!Matched::SymbolicUtils.Sym) at ~/.julia/packages/SymbolicUtils/fgHzN/src/methods.jl:68
  ...
Stacktrace:
  [1] (::SnoopCompile.var"#onclick#171"{Float64, Base.RefValue{Union{Method, SnoopCompile.MethodLoc}}})(event::PyCall.PyObject)
    @ SnoopCompile ~/.julia/packages/SnoopCompile/NF9Dd/src/visualizations.jl:32
  [2] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Base ./essentials.jl:716
  [3] invokelatest(::Any, ::Any, ::Vararg{Any})
    @ Base ./essentials.jl:714
  [4] _pyjlwrap_call(f::Function, args_::Ptr{PyCall.PyObject_struct}, kw_::Ptr{PyCall.PyObject_struct})
    @ PyCall ~/.julia/packages/PyCall/3fwVL/src/callback.jl:32
  [5] pyjlwrap_call(self_::Ptr{PyCall.PyObject_struct}, args_::Ptr{PyCall.PyObject_struct}, kw_::Ptr{PyCall.PyObject_struct})
    @ PyCall ~/.julia/packages/PyCall/3fwVL/src/callback.jl:44
  [6] macro expansion
    @ ~/.julia/packages/PyCall/3fwVL/src/exception.jl:95 [inlined]
  [7] #107
    @ ~/.julia/packages/PyCall/3fwVL/src/pyfncall.jl:43 [inlined]
  [8] disable_sigint
    @ ./c.jl:458 [inlined]
  [9] __pycall!
    @ ~/.julia/packages/PyCall/3fwVL/src/pyfncall.jl:42 [inlined]
 [10] _pycall!(ret::PyCall.PyObject, o::PyCall.PyObject, args::Tuple{PyCall.PyObject, PyCall.PyObject}, nargs::Int64, kw::Ptr{Nothing})
    @ PyCall ~/.julia/packages/PyCall/3fwVL/src/pyfncall.jl:29
 [11] _pycall!
    @ ~/.julia/packages/PyCall/3fwVL/src/pyfncall.jl:11 [inlined]
 [12] #pycall#112
    @ ~/.julia/packages/PyCall/3fwVL/src/pyfncall.jl:80 [inlined]
 [13] pycall
    @ ~/.julia/packages/PyCall/3fwVL/src/pyfncall.jl:80 [inlined]
 [14] (::PyCall.var"#3#4"{PyCall.PyObject, PyCall.PyObject, PyCall.PyObject, PyCall.PyObject})(async::Timer)
    @ PyCall ~/.julia/packages/PyCall/3fwVL/src/gui.jl:151
 [15] macro expansion
    @ ./asyncevent.jl:260 [inlined]
 [16] (::Base.var"#632#633"{PyCall.var"#3#4"{PyCall.PyObject, PyCall.PyObject, PyCall.PyObject, PyCall.PyObject}, Timer})()
    @ Base ./task.jl:123>
```

It seems that some of the `push`ed elements are `nothing`, which results in an error when calling `log(::Nothing)`. I'm not super familiar with the package, so I'm not sure if this is the best solution.