### PR TITLE
Slim precompile files for Julia 1.6+

### DIFF
--- a/docs/src/snoopi.md
+++ b/docs/src/snoopi.md
@@ -200,6 +200,11 @@ can lead to insights. For example, you might be able to introduce a precompile i
 dependent package that can mitigate the total time.
 (`@snoopi_deep` makes the analysis and resolution of these issues more straightforward.)
 
+!!! tip
+    For packages that support just Julia 1.6 and higher, you may be able to slim down the precompile file by
+    adding `has_bodyfunction=true` to the arguments for `parcel`.
+    This setting applies for all packges in `inf_timing`, so you may need to call `parcel` twice (with both `false` and `true`) and select the appropriate precompile file for each package.
+
 ## Producing precompile directives manually
 
 While this "automated" approach is often useful, sometimes it makes more sense to

--- a/docs/src/snoopi_deep_parcel.md
+++ b/docs/src/snoopi_deep_parcel.md
@@ -111,6 +111,11 @@ Base.Ryu: precompiled 0.15733664599999997 out of 0.15733664599999997
 Main.OptimizeMeFixed: precompiled 0.4204474180000001 out of 0.4204474180000001
 ```
 
+!!! tip
+    For packages that support just Julia 1.6 and higher, you may be able to slim down the precompile file by
+    adding `has_bodyfunction=true` to the arguments for `write`.
+    This setting applies for all packges in `pcs`, so you may need to call `write` twice (with both `false` and `true`) and select the appropriate precompile file for each package.
+
 You'll now find a directory `/tmp/precompiles_OptimizeMe`, and inside you'll find three files, for `Base`, `Base.Ryu`, and `OptimizeMeFixed`, respectively.
 The contents of the last of these should be recognizable:
 

--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -380,14 +380,14 @@ parcel(tinf::InferenceTimingNode; tmin=0.0, kwargs...) = parcel(precompilable_ro
 
 ### write
 
-function get_reprs(tmi::Vector{Tuple{Float64,MethodInstance}}; tmin=0.001)
+function get_reprs(tmi::Vector{Tuple{Float64,MethodInstance}}; tmin=0.001, kwargs...)
     strs = OrderedSet{String}()
     modgens = Dict{Module, Vector{Method}}()
     tmp = String[]
     twritten = 0.0
     for (t, mi) in reverse(tmi)
         if t >= tmin
-            if add_repr!(tmp, modgens, mi; check_eval=false, time=t)
+            if add_repr!(tmp, modgens, mi; check_eval=false, time=t, kwargs...)
                 str = pop!(tmp)
                 if !any(rex -> occursin(rex, str), default_exclusions)
                     push!(strs, str)

--- a/test/snoopi.jl
+++ b/test/snoopi.jl
@@ -137,6 +137,8 @@ uncompiled(x) = x + 1
                         length(mi.specTypes.parameters) >= 2 && mi.specTypes.parameters[end-1] === typeof(sortperm) && !(mi.specTypes.parameters[2] <: NamedTuple)
                     end)
             @test any(str->occursin("__lookup_kwbody__", str), FK)
+            pc2 = SnoopCompile.parcel(tinf; has_bodyfunction=true)
+            @test !any(str->occursin("__lookup_kwbody__", str), pc2[:Base])
         else
             @warn "Body method was not toplevel-inferred, test skipped"
         end

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -721,6 +721,20 @@ include("testmodules/SnoopBench.jl")
     @test isempty(prs)
     @test ttot2 == ttot
 
+    tinf = @snoopi_deep begin
+        fn = SnoopBench.sv()
+        rm(fn)
+    end
+    ttot, prs = SnoopCompile.parcel(tinf.children[1].children[1])
+    mod, (tmod, tmis) = only(prs)
+    io = IOBuffer()
+    SnoopCompile.write(io, tmis; tmin=0.0)
+    str = String(take!(io))
+    @test occursin("__lookup_kwbody__", str)
+    SnoopCompile.write(io, tmis; tmin=0.0, has_bodyfunction=true)
+    str = String(take!(io))
+    @test !occursin("__lookup_kwbody__", str)
+
     A = [a]
     tinf = @snoopi_deep SnoopBench.mappushes(identity, A)
     @test isempty(staleinstances(tinf))

--- a/test/testmodules/SnoopBench.jl
+++ b/test/testmodules/SnoopBench.jl
@@ -6,6 +6,15 @@ f3(::A) = 1
 f2(a::A) = f3(a)
 f1(a::A) = f2(a)
 
+function savevar(x; fn=joinpath(tempdir(), string(x)*".txt"))
+    open(fn, "w") do io
+        println(io, x)
+    end
+    return fn
+end
+
+sv() = savevar("horse")
+
 # Like map! except it uses push!
 # With a single call site
 mappushes!(f, dest, src) = (for item in src push!(dest, f(item)) end; return dest)


### PR DESCRIPTION
If a package only supports Julia versions that have `Base.bodyfunction`,
we don't need to define `__lookup_kwbody__`.
However, we can't simply query the running version of Julia,
because the precompile file may used by a different Julia version.
This adds a manual keyword argument.