### PR TITLE
Add SnoopPrecompile package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,13 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - run: julia --project -e 'using Pkg; Pkg.develop([PackageSpec(path="SnoopCompileCore")])'
+      - run: julia --project -e 'using Pkg; Pkg.develop([PackageSpec(path="SnoopPrecompile")])'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+      - run: julia --project=SnoopPrecompile -e 'using Pkg; Pkg.test()'
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: src,SnoopCompileCore/src
+          directories: src,SnoopCompileCore/src,SnoopPrecompile/src
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - run: julia --project -e 'using Pkg; Pkg.develop([PackageSpec(path="SnoopPrecompile")])'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
-      - run: julia --project=SnoopPrecompile -e 'using Pkg; Pkg.test()'
+      - run: julia --project=SnoopPrecompile -e 'using Pkg; Pkg.test(; coverage=true)'
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,SnoopCompileCore/src,SnoopPrecompile/src

--- a/SnoopPrecompile/LICENSE
+++ b/SnoopPrecompile/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Tim Holy <tim.holy@gmail.com> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SnoopPrecompile/Project.toml
+++ b/SnoopPrecompile/Project.toml
@@ -8,6 +8,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Test"]
+test = ["Test", "UUIDs"]

--- a/SnoopPrecompile/Project.toml
+++ b/SnoopPrecompile/Project.toml
@@ -1,0 +1,13 @@
+name = "SnoopPrecompile"
+uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
+version = "1.0.0"
+
+[compat]
+julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/SnoopPrecompile/README.md
+++ b/SnoopPrecompile/README.md
@@ -1,0 +1,5 @@
+# SnoopPrecompile
+
+SnoopPrecompile is a small dependency used to effectively precompile code needed by your package, particularly on Julia 1.8 and higher.
+
+See the [documentation]() for details.

--- a/SnoopPrecompile/src/SnoopPrecompile.jl
+++ b/SnoopPrecompile/src/SnoopPrecompile.jl
@@ -63,16 +63,11 @@ macro precompile_all_calls(ex::Expr)
             Core.Compiler.__set_measure_typeinf(true)
             try
                 $ex
-            catch e
-                err, bt = e, catch_backtrace()
             finally
                 Core.Compiler.__set_measure_typeinf(false)
                 Core.Compiler.Timings.close_current_timer()
             end
             SnoopPrecompile.precompile_roots(Core.Compiler.Timings._timings[1].children)
-            if err !== nothing
-                @warn "error in executing `@precompile_all_calls` expression" exception=(err,bt)
-            end
         end
     end
     return esc(quote

--- a/SnoopPrecompile/src/SnoopPrecompile.jl
+++ b/SnoopPrecompile/src/SnoopPrecompile.jl
@@ -1,0 +1,63 @@
+module SnoopPrecompile
+
+export @precompile_calls
+
+const verbose = Ref(false)    # if true, prints all the precompiles
+const have_inference_tracking = isdefined(Core.Compiler, :__set_measure_typeinf)
+const have_force_compile = isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("#@force_compile"))
+
+function precompile_roots(roots)
+    @assert have_inference_tracking
+    for child in roots
+        mi = child.mi_info.mi
+        precompile(mi.specTypes) # TODO: Julia should allow one to pass `mi` directly (would handle `invoke` properly)
+        verbose[] && println(mi)
+    end
+end
+
+macro precompile_calls(args...)
+    local sym, ex
+    if length(args) == 2
+        # This is tagged with a Symbol
+        isa(args[1], Symbol) || isa(args[1], QuoteNode) || throw(ArgumentError("expected a Symbol as the first argument to @precompile_calls, got $(typeof(args[1]))"))
+        isa(args[2], Expr) || throw(ArgumentError("expected an expression as the second argument to @precompile_calls, got $(typeof(args[2]))"))
+        sym = isa(args[1], Symbol) ? args[1]::Symbol : (args[1]::QuoteNode).value::Symbol
+        sym ∈ (:setup, :all) || throw(ArgumentError("first argument to @precompile_calls must be :setup or :all, got $(QuoteNode(sym))"))
+        ex = args[2]::Expr
+    else
+        length(args) == 1 || throw(ArgumentError("@precompile_calls accepts only one or two arguments"))
+        isa(args[1], Expr) || throw(ArgumentError("@precompile_calls expected an expression, got $(typeof(args[1]))"))
+        sym = :all
+        ex = args[1]::Expr
+    end
+    if sym == :all
+        if have_inference_tracking
+            ex = quote
+                Core.Compiler.Timings.reset_timings()
+                Core.Compiler.__set_measure_typeinf(true)
+                try
+                    $ex
+                finally
+                    Core.Compiler.__set_measure_typeinf(false)
+                    Core.Compiler.Timings.close_current_timer()
+                end
+                SnoopPrecompile.precompile_roots(Core.Compiler.Timings._timings[1].children)
+            end
+        elseif have_force_compile
+            ex = quote
+                begin
+                    Base.Experimental.@force_compile
+                    $ex
+                end
+            end
+        end
+    end
+    ex = quote
+        if ccall(:jl_generating_output, Cint, ()) == 1 || SnoopPrecompile.verbose[]
+            $ex
+        end
+    end
+    return esc(ex)
+end
+
+end

--- a/SnoopPrecompile/test/SnoopPC_A/Project.toml
+++ b/SnoopPrecompile/test/SnoopPC_A/Project.toml
@@ -1,0 +1,7 @@
+name = "SnoopPC_A"
+uuid = "13c4d82c-fea6-47db-9cd5-35bd2686c3b0"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"

--- a/SnoopPrecompile/test/SnoopPC_A/src/SnoopPC_A.jl
+++ b/SnoopPrecompile/test/SnoopPC_A/src/SnoopPC_A.jl
@@ -18,11 +18,11 @@ function call_findfirst(x, list)
 end
 
 let
-    @precompile_calls :setup begin
+    @precompile_setup begin
         list = [MyType(1), MyType(2), MyType(3)]
-    end
-    @precompile_calls begin
-        call_findfirst(MyType(2), list)
+        @precompile_all_calls begin
+            call_findfirst(MyType(2), list)
+        end
     end
 end
 

--- a/SnoopPrecompile/test/SnoopPC_A/src/SnoopPC_A.jl
+++ b/SnoopPrecompile/test/SnoopPC_A/src/SnoopPC_A.jl
@@ -1,0 +1,29 @@
+module SnoopPC_A
+
+using SnoopPrecompile
+
+struct MyType
+    x::Int
+end
+
+if isdefined(Base, :inferencebarrier)
+    inferencebarrier(@nospecialize(arg)) = Base.inferencebarrier(arg)
+else
+    inferencebarrier(@nospecialize(arg)) = Ref{Any}(arg)[]
+end
+
+function call_findfirst(x, list)
+    # call a method defined in Base by runtime dispatch
+    return findfirst(==(inferencebarrier(x)), inferencebarrier(list))
+end
+
+let
+    @precompile_calls :setup begin
+        list = [MyType(1), MyType(2), MyType(3)]
+    end
+    @precompile_calls begin
+        call_findfirst(MyType(2), list)
+    end
+end
+
+end # module SnoopPC_A

--- a/SnoopPrecompile/test/SnoopPC_B/Project.toml
+++ b/SnoopPrecompile/test/SnoopPC_B/Project.toml
@@ -1,0 +1,7 @@
+name = "SnoopPC_B"
+uuid = "d38b61e7-59a2-4ef9-b4d3-320bdc69b817"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"

--- a/SnoopPrecompile/test/SnoopPC_B/src/SnoopPC_B.jl
+++ b/SnoopPrecompile/test/SnoopPC_B/src/SnoopPC_B.jl
@@ -1,0 +1,7 @@
+module SnoopPC_B
+
+using SnoopPrecompile
+
+@precompile_all_calls missing_function(1)
+
+end # module SnoopPC_B

--- a/SnoopPrecompile/test/runtests.jl
+++ b/SnoopPrecompile/test/runtests.jl
@@ -1,8 +1,10 @@
 using SnoopPrecompile
 using Test
+using UUIDs
 
 @testset "SnoopPrecompile.jl" begin
     push!(LOAD_PATH, @__DIR__)
+
     using SnoopPC_A
     if Base.VERSION >= v"1.8.0-rc1"
         # Check that calls inside :setup are not precompiled
@@ -36,4 +38,13 @@ using Test
         end
         @test count == 1
     end
+
+    pipe = Pipe()
+    id = Base.PkgId(UUID("d38b61e7-59a2-4ef9-b4d3-320bdc69b817"), "SnoopPC_B")
+    redirect_stderr(pipe) do
+        @test_throws Exception Base.require(id)
+    end
+    close(pipe.in)
+    str = read(pipe.out, String)
+    @test occursin("UndefVarError: missing_function not defined", str)
 end

--- a/SnoopPrecompile/test/runtests.jl
+++ b/SnoopPrecompile/test/runtests.jl
@@ -1,0 +1,39 @@
+using SnoopPrecompile
+using Test
+
+@testset "SnoopPrecompile.jl" begin
+    push!(LOAD_PATH, @__DIR__)
+    using SnoopPC_A
+    if Base.VERSION >= v"1.8.0-rc1"
+        # Check that calls inside :setup are not precompiled
+        m = which(Tuple{typeof(Base.vect), Vararg{T}} where T)
+        have_mytype = false
+        for mi in m.specializations
+            mi === nothing && continue
+            have_mytype |= Base.unwrap_unionall(mi.specTypes).parameters[2] === SnoopPC_A.MyType
+        end
+        @test !have_mytype
+        # Check that calls inside @precompile_calls are precompiled
+        m = only(methods(SnoopPC_A.call_findfirst))
+        count = 0
+        for mi in m.specializations
+            mi === nothing && continue
+            sig = Base.unwrap_unionall(mi.specTypes)
+            @test sig.parameters[2] == SnoopPC_A.MyType
+            @test sig.parameters[3] == Vector{SnoopPC_A.MyType}
+            count += 1
+        end
+        @test count == 1
+        # Even one that was runtime-dispatched
+        m = which(Tuple{typeof(findfirst), Base.Fix2{typeof(==), T}, Vector{T}} where T)
+        count = 0
+        for mi in m.specializations
+            mi === nothing && continue
+            sig = Base.unwrap_unionall(mi.specTypes)
+            if sig.parameters[3] == Vector{SnoopPC_A.MyType}
+                count += 1
+            end
+        end
+        @test count == 1
+    end
+end

--- a/SnoopPrecompile/test/runtests.jl
+++ b/SnoopPrecompile/test/runtests.jl
@@ -39,12 +39,14 @@ using UUIDs
         @test count == 1
     end
 
-    pipe = Pipe()
-    id = Base.PkgId(UUID("d38b61e7-59a2-4ef9-b4d3-320bdc69b817"), "SnoopPC_B")
-    redirect_stderr(pipe) do
-        @test_throws Exception Base.require(id)
+    if Base.VERSION >= v"1.7"   # so we can use redirect_stderr(f, ::Pipe)
+        pipe = Pipe()
+        id = Base.PkgId(UUID("d38b61e7-59a2-4ef9-b4d3-320bdc69b817"), "SnoopPC_B")
+        redirect_stderr(pipe) do
+            @test_throws Exception Base.require(id)
+        end
+        close(pipe.in)
+        str = read(pipe.out, String)
+        @test occursin("UndefVarError: missing_function not defined", str)
     end
-    close(pipe.in)
-    str = read(pipe.out, String)
-    @test occursin("UndefVarError: missing_function not defined", str)
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(
     modules = [SnoopCompile.SnoopCompileCore, SnoopCompile],
     linkcheck = true,
     pages = ["index.md",
+             "snoop_pc.md",
              "tutorial.md",
              "Modern tools" => ["snoopr.md", "snoopi_deep.md", "pgdsgui.md", "snoopi_deep_analysis.md", "snoopi_deep_parcel.md", "jet.md"],
              "Older tools" => ["snoopi.md", "snoopc.md"],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -72,6 +72,12 @@ Finally, another alternative for reducing latency without any modifications
 to package files is [Revise](https://github.com/timholy/Revise.jl).
 It can be used in conjunction with SnoopCompile.
 
+## Basic usage: SnoopPrecompile
+
+The "SnoopCompile family" includes a very small package, `SnoopPrecompile` (which does not require `SnoopCompile` itself),
+with which most packages can easily and effectively precompile code, particularly for Julia versions 1.8 and higher.
+See the [SnoopPrecompile](@ref) documentation.
+
 ## [A note on Julia versions and the recommended workflow](@id workflow)
 
 SnoopCompile is closely intertwined with Julia's own internals.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -78,6 +78,9 @@ The "SnoopCompile family" includes a very small package, `SnoopPrecompile` (whic
 with which most packages can easily and effectively precompile code, particularly for Julia versions 1.8 and higher.
 See the [SnoopPrecompile](@ref) documentation.
 
+For many package developers, `SnoopPrecompile` may be all you need. In case of trouble (or if you want to check that
+`SnoopPrecompile` did its job thoroughly), the rest of `SnoopCompile` provides more sophisticated diagnostics.
+
 ## [A note on Julia versions and the recommended workflow](@id workflow)
 
 SnoopCompile is closely intertwined with Julia's own internals.

--- a/docs/src/snoop_pc.md
+++ b/docs/src/snoop_pc.md
@@ -1,0 +1,70 @@
+# SnoopPrecompile
+
+SnoopPrecompile provides a macro, `@precompile_calls`, which precompiles every call on its first usage.
+The key feature of `@precompile_calls` is that it intercepts all callees (including those made by runtime dispatch) and, on Julia 1.8 and higher, allows you to precompile the callee even if it comes from a different module (e.g., `Base` or a different package).
+
+Statements that occur inside a `@precompile_calls` block are executed only if the package is being actively precompiled;
+it does not run when the package is loaded, nor if you're running Julia with `--compiled-modules=no`.
+
+Here's an illustration of how you might use `@precompile_calls`:
+
+```julia
+module MyPackage
+
+using SnoopPrecompile    # this is a small dependency
+
+struct MyType
+    x::Int
+end
+struct OtherType
+    str::String
+end
+
+let  # `let` prevents `list` from being a visible private name in the package
+    @precompile_calls :setup beginNaturally, y
+        # Putting some things in `:setup` can reduce the size of the
+        # precompile file and potentially make loading faster.
+        list = [OtherType("hello"), OtherType("world!")]
+    end
+    @precompile_calls begin
+        # all calls in this block will be precompiled, regardless of whether
+        # they belong to your package or not (on Julia 1.8 and higher)
+        d = Dict(MyType(1) => list)
+        x = get(d, MyType(2), nothing)
+        last(d[MyType(1)])
+    end
+end
+
+end
+```
+
+When you build `MyPackage`, it will precompile the following, *including all their callees*:
+
+- `Pair(::MyPackage.MyType, ::Vector{MyPackage.OtherType})`
+- `Dict(::Pair{MyPackage.MyType, Vector{MyPackage.OtherType}})`
+- `get(::Dict{MyPackage.MyType, Vector{MyPackage.OtherType}}, ::MyPackage.MyType, ::Nothing)`
+- `getindex(::Dict{MyPackage.MyType, Vector{MyPackage.OtherType}}, ::MyPackage.MyType)`
+- `last(::Vector{MyPackage.OtherType})`
+
+In this case, the "top level" calls were fully inferrable, so there are no additional
+entries on this list that were called by runtime dispatch. Thus, here you could have gotten
+the same result with manual `precompile` directives.
+The key advantage of `@precompile_calls` is that it works even if the functions you're calling
+have runtime dispatch.
+
+If you want to see the list of calls that will be precompiled, navigate to the `MyPackage` folder and use
+
+```julia
+julia> using SnoopPrecompile
+
+julia> SnoopPrecompile.verbose[] = true   # runs the block even if you're not precompiling, and print precompiled calls
+
+julia> include("src/MyPackage.jl");
+```
+
+!!! note
+    Any calls that are already inferred prior to `@precompile_calls` may not be cached in the
+    package, unless they are for methods that belong to your package. You can use multiple
+    `@precompile_calls` blocks if you need to interleave `:setup` code with code that will precompile.
+    You can use `@snoopi_deep` to check for any (re)inference when you use the code in your package.
+    To fix any specific problems, you can combine `@precompile_calls` with manual `precompile` directives.

--- a/docs/src/snoop_pc.md
+++ b/docs/src/snoop_pc.md
@@ -1,12 +1,15 @@
 # SnoopPrecompile
 
-SnoopPrecompile provides a macro, `@precompile_calls`, which precompiles every call on its first usage.
-The key feature of `@precompile_calls` is that it intercepts all callees (including those made by runtime dispatch) and, on Julia 1.8 and higher, allows you to precompile the callee even if it comes from a different module (e.g., `Base` or a different package).
+SnoopPrecompile provides a macro, `@precompile_all_calls`, which precompiles every call on its first usage.
+The key feature of `@precompile_all_calls` is that it intercepts all callees (including those made by runtime dispatch) and, on Julia 1.8 and higher, allows you to precompile the callee even if it comes from a different module (e.g., `Base` or a different package).
 
-Statements that occur inside a `@precompile_calls` block are executed only if the package is being actively precompiled;
+Statements that occur inside a `@precompile_all_calls` block are executed only if the package is being actively precompiled;
 it does not run when the package is loaded, nor if you're running Julia with `--compiled-modules=no`.
 
-Here's an illustration of how you might use `@precompile_calls`:
+SnoopPrecompile also exports `@precompile_setup`, which you can use to create data for use inside a `@precompile_all_calls` block. Like `@precompile_all_calls`, this code only runs when you are precompiling the package, but it does not
+necessarily result in the "setup" code being stored in the package precompile file.
+
+Here's an illustration of how you might use `@precompile_all_calls` and `@precompile_setup`:
 
 ```julia
 module MyPackage
@@ -20,11 +23,11 @@ struct OtherType
     str::String
 end
 
-@precompile_calls :setup begin
-    # Putting some things in `:setup` can reduce the size of the
+@precompile_setup begin
+    # Putting some things in `setup` can reduce the size of the
     # precompile file and potentially make loading faster.
     list = [OtherType("hello"), OtherType("world!")]
-    @precompile_calls begin
+    @precompile_all_calls all_begin
         # all calls in this block will be precompiled, regardless of whether
         # they belong to your package or not (on Julia 1.8 and higher)
         d = Dict(MyType(1) => list)
@@ -47,7 +50,7 @@ When you build `MyPackage`, it will precompile the following, *including all the
 In this case, the "top level" calls were fully inferrable, so there are no entries on this list
 that were called by runtime dispatch. Thus, here you could have gotten the same result with manual
 `precompile` directives.
-The key advantage of `@precompile_calls` is that it works even if the functions you're calling
+The key advantage of `@precompile_all_calls` is that it works even if the functions you're calling
 have runtime dispatch.
 
 If you want to see the list of calls that will be precompiled, navigate to the `MyPackage` folder and use
@@ -61,19 +64,19 @@ julia> include("src/MyPackage.jl");
 ```
 
 Once you set up `SnoopPrecompile`, try your package and see if it reduces the time to first execution,
-using the same workload you put inside the `@precompile_calls` block.
+using the same workload you put inside the `@precompile_all_calls` block.
 
 If you're happy with the results, you're done! If you want deeper verification of whether it worked as
 expected, or if you suspect problems, then the rest of SnoopCompile provides additional tools.
 Potential sources of trouble include invalidation (see [`@snoopr`](@ref) and related) and omission of
-intended calls from inside the `@precompile_calls` block (see [`@snoopi_deep`](@ref) and related).
+intended calls from inside the `@precompile_all_calls` block (see [`@snoopi_deep`](@ref) and related).
 
 !!! note
-    `@precompile_calls` works by monitoring type-inference. If the code was already inferred
-    prior to `@precompile_calls` (e.g., from prior usage), you might omit any external
+    `@precompile_all_calls` works by monitoring type-inference. If the code was already inferred
+    prior to `@precompile_all_calls` (e.g., from prior usage), you might omit any external
     methods that were called via runtime dispatch.
 
-    You can use multiple `@precompile_calls` blocks if you need to interleave `:setup` code with
+    You can use multiple `@precompile_all_calls` blocks if you need to interleave "setup" code with
     code that you want precompiled.
     You can use `@snoopi_deep` to check for any (re)inference when you use the code in your package.
-    To fix any specific problems, you can combine `@precompile_calls` with manual `precompile` directives.
+    To fix any specific problems, you can combine `@precompile_all_calls` with manual `precompile` directives.


### PR DESCRIPTION
This small package makes it easy to exhaustively precompile on
Julia 1.8 and higher. In brief, your package should look like

```julia
module MyPackage

using SnoopPrecompile

# method definitions etc

let
    @precompile_calls begin
        # execute the code you want precompiled
    end
end

end # module MyPackage
```

There are also facilities for "setup" code, see the documentation
for details.