### PR TITLE
Fix undefined `SnoopPrecompile`

### DIFF
--- a/SnoopPrecompile/Project.toml
+++ b/SnoopPrecompile/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopPrecompile"
 uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [compat]
 julia = "1"

--- a/SnoopPrecompile/src/SnoopPrecompile.jl
+++ b/SnoopPrecompile/src/SnoopPrecompile.jl
@@ -68,11 +68,11 @@ macro precompile_all_calls(ex::Expr)
                 Core.Compiler.__set_measure_typeinf(false)
                 Core.Compiler.Timings.close_current_timer()
             end
-            SnoopPrecompile.precompile_roots(Core.Compiler.Timings._timings[1].children)
+            $SnoopPrecompile.precompile_roots(Core.Compiler.Timings._timings[1].children)
         end
     end
     return esc(quote
-        if ccall(:jl_generating_output, Cint, ()) == 1 || SnoopPrecompile.verbose[]
+        if ccall(:jl_generating_output, Cint, ()) == 1 || $SnoopPrecompile.verbose[]
             $ex
         end
     end)
@@ -103,7 +103,7 @@ to your package).
 macro precompile_setup(ex::Expr)
     return esc(quote
         # let
-            if ccall(:jl_generating_output, Cint, ()) == 1 || SnoopPrecompile.verbose[]
+            if ccall(:jl_generating_output, Cint, ()) == 1 || $SnoopPrecompile.verbose[]
                 $ex
             end
         # end

--- a/SnoopPrecompile/test/SnoopPC_A/src/SnoopPC_A.jl
+++ b/SnoopPrecompile/test/SnoopPC_A/src/SnoopPC_A.jl
@@ -1,6 +1,6 @@
 module SnoopPC_A
 
-using SnoopPrecompile
+using SnoopPrecompile: @precompile_setup, @precompile_all_calls
 
 struct MyType
     x::Int


### PR DESCRIPTION
Fixes
```
ERROR: LoadError: UndefVarError: SnoopPrecompile not defined
Stacktrace:
 [1] macro expansion
   @ ~/.julia/packages/SnoopPrecompile/bsz6N/src/SnoopPrecompile.jl:71 [inlined]
 [2] macro expansion
[...]
```
when loading the module via `using SnoopPrecompile: @precompile_setup, @precompile_all_calls`.