### PR TITLE
Link to dev documentation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ loading packages and using them to do "real work."
 
 See the documentation:
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://timholy.github.io/SnoopCompile.jl/stable)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://timholy.github.io/SnoopCompile.jl/dev/)


### PR DESCRIPTION
`SnoopPrecompile.jl` is not yet visible in the stable docs because `SnoopCompile.jl` hasn't been updated after the addition of `SnoopPrecompile.jl`. Long story short, probably best to refer people to the dev docs by default. If agreeing with this change, then don't forget to update the link in the top-right at the GitHub repository too.