### PR TITLE
Implement more powerful tree-join, fix tests on Julia-1.8

### DIFF
--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -889,7 +889,7 @@ end
         end
         @test isempty(SnoopCompile.StaleTree(first(smis).def, :noreason).backedges)  # constructor test
         healed = true
-        if Base.VERSION < v"1.9.0-DEV.79" || Base.VERSION < v"1.8.0-beta2"
+        if Base.VERSION < v"1.8"
             healed = false
             # On more recent Julia, the invalidation of StaleA.stale is "healed over" by re-inferrence
             # within StaleC. Hence we should skip this test.

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -266,7 +266,7 @@ end
         @test tree.reason == :inserting
         mi1, mi2 = tree.mt_backedges[1]
         @test mi1 == callee
-        @test mi2 == caller
+        @test mi2.mi == caller
         @test Core.MethodInstance(tree.backedges[1]) == callee
         io = IOBuffer()
         print(io, tree)


### PR DESCRIPTION
Julia-1.8 reports invalidations slightly differently from previous
versions. This harmonizes the output and avoids duplicating
trees/roots/branches.

While this suffices to fix SnoopCompile on 1.8, nightly will require additional work (failure anticipated).