### PR TITLE
Fix warning during precompilation

### DIFF
--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -287,7 +287,7 @@ Precompiles(node::InferenceTimingNode) = Precompiles(InferenceTiming(node).mi_in
 
 Core.MethodInstance(pc::Precompiles) = MethodInstance(pc.mi_info)
 SnoopCompileCore.inclusive(pc::Precompiles) = pc.total_time
-precompilable_time(precompiles::Vector{Tuple{Float64,MethodInstance}}) where T = sum(first, precompiles; init=0.0)
+precompilable_time(precompiles::Vector{Tuple{Float64,MethodInstance}}) = sum(first, precompiles; init=0.0)
 precompilable_time(precompiles::Dict{MethodInstance,T}) where T = sum(values(precompiles); init=zero(T))
 precompilable_time(pc::Precompiles) = precompilable_time(pc.precompiles)
 


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/46608 gave rise to a warning during precompilation of SnoopCompile:

```jl
julia> using SnoopCompile
[ Info: Precompiling SnoopCompile [aa65fe97-06da-5843-b5b1-d5d13cad87d2]
WARNING: method definition for precompilable_time at /home/tchr/.julia/packages/SnoopCompile/J3dtR/src/parcel_snoopi_deep.jl:290 declares type variable T but does not use it.
```