### PR TITLE
Integrate JET via Requires.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,13 @@
 name = "SnoopCompile"
 uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "2.9.5"
+version = "3.0.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Cthulhu = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -25,7 +24,7 @@ FlameGraphs = "0.2, 1"
 JET = "0.0, 0.4, 0.5, 0.6"
 OrderedCollections = "1"
 Requires = "1"
-SnoopCompileCore = "~2.9.0"
+SnoopCompileCore = "~3.0.0"
 YAML = "0.4"
 julia = "1"
 
@@ -33,10 +32,11 @@ julia = "1"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ColorTypes", "Documenter", "FixedPointNumbers", "MethodAnalysis", "Pkg", "Random", "Test"]
+test = ["ColorTypes", "Documenter", "FixedPointNumbers", "JET", "MethodAnalysis", "Pkg", "Random", "Test"]

--- a/SnoopCompileCore/Project.toml
+++ b/SnoopCompileCore/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompileCore"
 uuid = "e2b509da-e806-4183-be48-004708413034"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "2.9.0"
+version = "3.0.0"
 
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/docs/src/jet.md
+++ b/docs/src/jet.md
@@ -91,7 +91,7 @@ As always, you need to do the data collection in a fresh session where the calls
 After restarting Julia, we can do this:
 
 ```
-julia> using SnoopCompile
+julia> using SnoopCompile, JET
 
 julia> list = Any[1,2,3];
 

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -92,7 +92,6 @@ if isdefined(SnoopCompileCore, Symbol("@snoopi_deep"))
     include("deep_demos.jl")
     export @snoopi_deep, exclusive, inclusive, flamegraph, flatten, accumulate_by_source, collect_for, runtime_inferencetime, staleinstances
     export InferenceTrigger, inference_triggers, callerinstance, callingframe, skiphigherorder, trigger_tree, suggest, isignorable
-    export report_callee, report_caller, report_callees
 end
 
 if isdefined(SnoopCompileCore, Symbol("@snoopl"))

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -119,6 +119,9 @@ function __init__()
     if isdefined(SnoopCompile, :runtime_inferencetime)
         @require PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee" include("visualizations.jl")
     end
+    if isdefined(SnoopCompile, :inference_triggers)
+        @require JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b" include("jet_integration.jl")
+    end
 end
 
 end # module

--- a/src/jet_integration.jl
+++ b/src/jet_integration.jl
@@ -1,0 +1,72 @@
+using .JET
+
+"""
+    report_callee(itrig::InferenceTrigger)
+
+Return the `JET.report_call` for the callee in `itrig`.
+"""
+report_callee(itrig::InferenceTrigger; jetconfigs...) = report_call(Cthulhu.specTypes(itrig); jetconfigs...)
+
+"""
+    report_caller(itrig::InferenceTrigger)
+
+Return the `JET.report_call` for the caller in `itrig`.
+"""
+report_caller(itrig::InferenceTrigger; jetconfigs...) = report_call(Cthulhu.specTypes(callerinstance(itrig)); jetconfigs...)
+
+"""
+    report_callees(itrigs)
+
+Filter `itrigs` for those with a non-passing `JET` report, returning the list of `itrig => report` pairs.
+
+# Examples
+
+```jldoctest jetfib; setup=(using SnoopCompile, JET), filter=r"[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?/[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?"
+julia> fib(n::Integer) = n ≤ 2 ? n : fib(n-1) + fib(n-2);
+
+julia> function fib(str::String)
+           n = length(str)
+           return fib(m)    # error is here
+       end
+fib (generic function with 2 methods)
+
+julia> fib(::Dict) = 0; fib(::Vector) = 0;
+
+julia> list = [5, "hello"];
+
+julia> mapfib(list) = map(fib, list)
+mapfib (generic function with 1 method)
+
+julia> tinf = @snoopi_deep try mapfib(list) catch end
+InferenceTimingNode: 0.049825/0.071476 on Core.Compiler.Timings.ROOT() with 5 direct children
+
+julia> @report_call mapfib(list)
+No errors !
+```
+
+JET did not catch the error because the call to `fib` is hidden behind runtime dispatch.
+However, when captured by `@snoopi_deep`, we get
+
+```jldoctest jetfib; filter=[r"@ .*", r"REPL\\[\\d+\\]|none"]
+julia> report_callees(inference_triggers(tinf))
+1-element Vector{Pair{InferenceTrigger, JET.JETCallResult{JET.JETAnalyzer{JET.BasicPass{typeof(JET.basic_function_filter)}}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}}}}:
+ Inference triggered to call fib(::String) from iterate (./generator.jl:47) inlined into Base.collect_to!(::Vector{Int64}, ::Base.Generator{Vector{Any}, typeof(fib)}, ::Int64, ::Int64) (./array.jl:782) => ═════ 1 possible error found ═════
+┌ @ none:3 fib(m)
+│ variable m is not defined: fib(m)
+└──────────
+```
+"""
+function report_callees(itrigs; jetconfigs...)
+    function rr(itrig)
+        rpt = try
+            report_callee(itrig; jetconfigs...)
+        catch err
+            @warn "skipping $itrig due to report_callee error" exception=err
+            nothing
+        end
+        return itrig => rpt
+    end
+    hasreport((itrig, report)) = report !== nothing && !isempty(JET.get_reports(report))
+
+    return [itrigrpt for itrigrpt in map(rr, itrigs) if hasreport(itrigrpt)]
+end

--- a/src/jet_integration.jl
+++ b/src/jet_integration.jl
@@ -1,5 +1,7 @@
 using .JET
 
+export report_callee, report_caller, report_callees
+
 """
     report_callee(itrig::InferenceTrigger)
 

--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -7,7 +7,6 @@ using Core.Compiler.Timings: InferenceFrameInfo
 using SnoopCompileCore: InferenceTiming, InferenceTimingNode, inclusive, exclusive
 using Profile
 using Cthulhu
-using JET
 
 const InferenceNode = Union{InferenceFrameInfo,InferenceTiming,InferenceTimingNode}
 
@@ -896,77 +895,6 @@ Cthulhu.method(itrig::InferenceTrigger) = Method(itrig.node)
 Cthulhu.specTypes(itrig::InferenceTrigger) = Cthulhu.specTypes(Cthulhu.instance(itrig))
 Cthulhu.backedges(itrig::InferenceTrigger) = (itrig.callerframes,)
 Cthulhu.nextnode(itrig::InferenceTrigger, edge) = (ret = callingframe(itrig); return isempty(ret.callerframes) ? nothing : ret)
-
-"""
-    report_callee(itrig::InferenceTrigger)
-
-Return the `JET.report_call` for the callee in `itrig`.
-"""
-report_callee(itrig::InferenceTrigger; jetconfigs...) = report_call(Cthulhu.specTypes(itrig); jetconfigs...)
-
-"""
-    report_caller(itrig::InferenceTrigger)
-
-Return the `JET.report_call` for the caller in `itrig`.
-"""
-report_caller(itrig::InferenceTrigger; jetconfigs...) = report_call(Cthulhu.specTypes(callerinstance(itrig)); jetconfigs...)
-
-"""
-    report_callees(itrigs)
-
-Filter `itrigs` for those with a non-passing `JET` report, returning the list of `itrig => report` pairs.
-
-# Examples
-
-```jldoctest jetfib; setup=(using SnoopCompile, JET), filter=r"[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?/[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?"
-julia> fib(n::Integer) = n ≤ 2 ? n : fib(n-1) + fib(n-2);
-
-julia> function fib(str::String)
-           n = length(str)
-           return fib(m)    # error is here
-       end
-fib (generic function with 2 methods)
-
-julia> fib(::Dict) = 0; fib(::Vector) = 0;
-
-julia> list = [5, "hello"];
-
-julia> mapfib(list) = map(fib, list)
-mapfib (generic function with 1 method)
-
-julia> tinf = @snoopi_deep try mapfib(list) catch end
-InferenceTimingNode: 0.049825/0.071476 on Core.Compiler.Timings.ROOT() with 5 direct children
-
-julia> @report_call mapfib(list)
-No errors !
-```
-
-JET did not catch the error because the call to `fib` is hidden behind runtime dispatch.
-However, when captured by `@snoopi_deep`, we get
-
-```jldoctest jetfib; filter=[r"@ .*", r"REPL\\[\\d+\\]|none"]
-julia> report_callees(inference_triggers(tinf))
-1-element Vector{Pair{InferenceTrigger, JET.JETCallResult{JET.JETAnalyzer{JET.BasicPass{typeof(JET.basic_function_filter)}}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}}}}:
- Inference triggered to call fib(::String) from iterate (./generator.jl:47) inlined into Base.collect_to!(::Vector{Int64}, ::Base.Generator{Vector{Any}, typeof(fib)}, ::Int64, ::Int64) (./array.jl:782) => ═════ 1 possible error found ═════
-┌ @ none:3 fib(m)
-│ variable m is not defined: fib(m)
-└──────────
-```
-"""
-function report_callees(itrigs; jetconfigs...)
-    function rr(itrig)
-        rpt = try
-            report_callee(itrig; jetconfigs...)
-        catch err
-            @warn "skipping $itrig due to report_callee error" exception=err
-            nothing
-        end
-        return itrig => rpt
-    end
-    hasreport((itrig, report)) = report !== nothing && !isempty(JET.get_reports(report))
-
-    return [itrigrpt for itrigrpt in map(rr, itrigs) if hasreport(itrigrpt)]
-end
 
 filtermod(mod::Module, itrigs::AbstractVector{InferenceTrigger}) = filter(==(mod) ∘ callermodule, itrigs)
 

--- a/test/jet_integration.jl
+++ b/test/jet_integration.jl
@@ -1,0 +1,18 @@
+using Test
+using JET
+using SnoopCompile
+
+if Base.VERSION >= v"1.7"
+    @testset "JET integration" begin
+        f(c) = sum(c[1])
+        c = Any[Any[1,2,3]]
+        tinf = @snoopi_deep f(c)
+        rpt = JET.@report_call f(c)
+        @test isempty(JET.get_reports(rpt))
+        itrigs = inference_triggers(tinf)
+        irpts = report_callees(itrigs)
+        @test only(irpts).first == last(itrigs)
+        @test !isempty(JET.get_reports(only(irpts).second))
+        @test  isempty(JET.get_reports(report_caller(itrigs[end])))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,3 +116,6 @@ end
 
 include("colortypes.jl")
 
+if Base.VERSION >= v"1.7"
+    include("jet_integration.jl")
+end

--- a/test/snoopi_deep.jl
+++ b/test/snoopi_deep.jl
@@ -943,18 +943,3 @@ end
     end
     Pkg.activate(cproj)
 end
-
-if Base.VERSION >= v"1.7"
-    @testset "JET integration" begin
-        f(c) = sum(c[1])
-        c = Any[Any[1,2,3]]
-        tinf = @snoopi_deep f(c)
-        rpt = SnoopCompile.JET.@report_call f(c)
-        @test isempty(SnoopCompile.JET.get_reports(rpt))
-        itrigs = inference_triggers(tinf)
-        irpts = report_callees(itrigs)
-        @test only(irpts).first == last(itrigs)
-        @test !isempty(SnoopCompile.JET.get_reports(only(irpts).second))
-        @test  isempty(SnoopCompile.JET.get_reports(report_caller(itrigs[end])))
-    end
-end


### PR DESCRIPTION
Both SnoopCompile and JET are difficult to keep compatible with nightly and across older versions of Julia, so requiring that both are working (or even, just precompiling) simultaneously is twice the risk. If we put the JET integration under `@require`, then we can load SnoopCompile without JET.

The sad part is that this should probably be viewed as a breaking change (now users have to manually load JET) and thus we need to go to 3.0.0.