### PR TITLE
Fix attribution of "delayed" invalidations

### DIFF
--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -287,7 +287,7 @@ Precompiles(node::InferenceTimingNode) = Precompiles(InferenceTiming(node).mi_in
 
 Core.MethodInstance(pc::Precompiles) = MethodInstance(pc.mi_info)
 SnoopCompileCore.inclusive(pc::Precompiles) = pc.total_time
-precompilable_time(precompiles::Vector{Tuple{Float64,MethodInstance}}) where T = sum(first, precompiles; init=0.0)
+precompilable_time(precompiles::Vector{Tuple{Float64,MethodInstance}}) = sum(first, precompiles; init=0.0)
 precompilable_time(precompiles::Dict{MethodInstance,T}) where T = sum(values(precompiles); init=zero(T))
 precompilable_time(pc::Precompiles) = precompilable_time(pc.precompiles)
 

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -230,7 +230,7 @@ end
 end
 
 @testset "Delayed invalidations" begin
-    if true   # FIXME Julia version
+    if Base.VERSION >= v"1.9.0-DEV.1432"  # julia#46756
         cproj = Base.active_project()
         cd(joinpath(@__DIR__, "testmodules", "Invalidation")) do
             Pkg.activate(pwd())

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -1,4 +1,4 @@
-using SnoopCompile, InteractiveUtils, MethodAnalysis, Test
+using SnoopCompile, InteractiveUtils, MethodAnalysis, Pkg, Test
 
 const qualify_mi = Base.VERSION >= v"1.7.0-DEV.5"  # julia PR #38608
 
@@ -230,7 +230,31 @@ end
 end
 
 @testset "Delayed invalidations" begin
-    if Base.VERSION >= v"1.7.0-DEV.254"   # julia#39132 (redirect to Pipe)
+    if true   # FIXME Julia version
+        cproj = Base.active_project()
+        cd(joinpath(@__DIR__, "testmodules", "Invalidation")) do
+            Pkg.activate(pwd())
+            Pkg.develop(path="./PkgC")
+            Pkg.develop(path="./PkgD")
+            Pkg.precompile()
+            invalidations = @snoopr begin
+                @eval begin
+                    using PkgC
+                    PkgC.nbits(::UInt8) = 8
+                    using PkgD
+                end
+            end
+            tree = only(invalidation_trees(invalidations))
+            @test tree.reason == :inserting
+            @test tree.method.file == Symbol(@__FILE__)
+            @test isempty(tree.backedges)
+            sig, root = only(tree.mt_backedges)
+            @test sig.parameters[1] === typeof(PkgC.nbits)
+            @test sig.parameters[2] === Integer
+            @test root.mi == only(methods(PkgD.call_nbits)).specializations[1]
+        end
+        Pkg.activate(cproj)
+    elseif Base.VERSION >= v"1.7.0-DEV.254"   # julia#39132 (redirect to Pipe)
         # "Natural" tests are performed in the "Stale" testset of "snoopi_deep.jl"
         # because they are also used for precompile_blockers.
         # Here we craft them artificially.

--- a/test/testmodules/Invalidation/Manifest.toml
+++ b/test/testmodules/Invalidation/Manifest.toml
@@ -1,0 +1,16 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.9.0-DEV"
+manifest_format = "2.0"
+project_hash = "0bc27949c56990fdb6d1c736921aa6799da2d200"
+
+[[deps.PkgC]]
+path = "PkgC"
+uuid = "c8e0c308-2b2c-4e17-bb0b-031502754b83"
+version = "0.1.0"
+
+[[deps.PkgD]]
+deps = ["PkgC"]
+path = "PkgD"
+uuid = "3a5fa9f4-f0a4-4856-859e-2bf0c30232a7"
+version = "0.1.0"

--- a/test/testmodules/Invalidation/PkgC/Project.toml
+++ b/test/testmodules/Invalidation/PkgC/Project.toml
@@ -1,0 +1,4 @@
+name = "PkgC"
+uuid = "c8e0c308-2b2c-4e17-bb0b-031502754b83"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"

--- a/test/testmodules/Invalidation/PkgC/src/PkgC.jl
+++ b/test/testmodules/Invalidation/PkgC/src/PkgC.jl
@@ -1,0 +1,6 @@
+module PkgC
+
+nbits(::Int8) = 8
+nbits(::Int16) = 16
+
+end # module PkgC

--- a/test/testmodules/Invalidation/PkgD/Manifest.toml
+++ b/test/testmodules/Invalidation/PkgD/Manifest.toml
@@ -1,0 +1,10 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.9.0-DEV"
+manifest_format = "2.0"
+project_hash = "605498a297918c5643f56853f77795466548669e"
+
+[[deps.PkgC]]
+path = "../PkgC"
+uuid = "c8e0c308-2b2c-4e17-bb0b-031502754b83"
+version = "0.1.0"

--- a/test/testmodules/Invalidation/PkgD/Project.toml
+++ b/test/testmodules/Invalidation/PkgD/Project.toml
@@ -1,0 +1,7 @@
+name = "PkgD"
+uuid = "3a5fa9f4-f0a4-4856-859e-2bf0c30232a7"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+PkgC = "c8e0c308-2b2c-4e17-bb0b-031502754b83"

--- a/test/testmodules/Invalidation/PkgD/src/PkgD.jl
+++ b/test/testmodules/Invalidation/PkgD/src/PkgD.jl
@@ -1,0 +1,11 @@
+module PkgD
+
+using PkgC
+
+call_nbits(x::Integer) = PkgC.nbits(x)
+map_nbits(list) = map(call_nbits, list)
+nbits_list() = map_nbits(Integer[Int8(1), Int16(1)])
+
+nbits_list()
+
+end # module PkgD

--- a/test/testmodules/Invalidation/Project.toml
+++ b/test/testmodules/Invalidation/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+PkgC = "c8e0c308-2b2c-4e17-bb0b-031502754b83"
+PkgD = "3a5fa9f4-f0a4-4856-859e-2bf0c30232a7"


### PR DESCRIPTION
"Delayed" invalidations occur during package loading in response to some event that happened before
the package was loaded. Because the trigger is separated in time from its consequences, we did not formerly have a mechanism to clearly attribute these to a cause. Julia 1.9 has recently added more logging to make this more robust; this PR updates SnoopCompile to take advantage of the new information.

Fixes the confusing output mentioned in https://github.com/timholy/SnoopCompile.jl/issues/296#issuecomment-1245562684 (CC @joa-quim).