### PR TITLE
Add `report_invalidations` to tabulate invalidations summary

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,4 +40,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ColorTypes", "Documenter", "FixedPointNumbers", "MethodAnalysis", "Pkg", "Random", "Test"]
+test = ["ColorTypes", "PrettyTables", "Documenter", "FixedPointNumbers", "MethodAnalysis", "Pkg", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -35,6 +35,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -119,6 +119,8 @@ function __init__()
     if isdefined(SnoopCompile, :runtime_inferencetime)
         @require PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee" include("visualizations.jl")
     end
+
+    @require PettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d" include("report_invalidations.jl")
 end
 
 end # module

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -119,8 +119,10 @@ function __init__()
     if isdefined(SnoopCompile, :runtime_inferencetime)
         @require PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee" include("visualizations.jl")
     end
-
-    @require PettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d" include("report_invalidations.jl")
+    if isdefined(SnoopCompileCore, Symbol("@snoopr"))
+        @require PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d" include("report_invalidations.jl")
+    end
+    return nothing
 end
 
 end # module

--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -256,8 +256,8 @@ else
 end
 
 """
-    report_invalidations(;
-        job_name::String = "",
+    report_invalidations(
+        io::IO = stdout;
         invalidations,
         n_rows::Int = 10,
         process_filename::Function = x -> x,
@@ -265,10 +265,19 @@ end
 
 Print a tabular summary of invalidations given:
 
- - `job_name::String` the name of the job
+ - `invalidations` the output of [`SnoopCompileCore.@snoopr`](@ref)
 
-An `@info` message also prints some information, for example
-if the table has been truncated (upon request).
+and (optionally)
+
+ - `io::IO` IO stream. Defaults to `stdout`
+ - `n_rows::Int` the number of rows to be displayed in the
+   truncated table. A value of 0 indicates no truncation.
+   A positive value will truncate the table to the specified
+   number of rows.
+ - `process_filename(::String)::String` a function to post-process
+   each filename, where invalidations are found
+
+# Example usage
 
 ```julia
 import SnoopCompileCore
@@ -280,10 +289,7 @@ end;
 
 using SnoopCompile
 using PrettyTables # to load report_invalidations
-report_invalidations(;
-    job_name = "MyWork",
-    invalidations,
-)
+report_invalidations(;invalidations)
 ```
 
 Using `report_invalidations` requires that you first load the `PrettyTables.jl` package.

--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -256,16 +256,15 @@ else
 end
 
 """
-    tabulated_invalidations(;
+    report_invalidations(;
         job_name::String,
         invalidations,
         n_rows::Int = 10,
         process_filename::Function = x -> x,
     )
 
-A NamedTuple, `(; table_data, header)`, which
-contains a condensed form of invalidations in the form
-of a matrix and a header, which can be easily tabulated.
+Print a tabular summary of invalidations.
+
 An `@info` message also prints some information, for example
 if the table has been truncated (upon request).
 
@@ -277,66 +276,16 @@ invalidations = SnoopCompileCore.@snoopr begin
 
 end;
 
-import SnoopCompile
-(; table_data, header) = SnoopCompile.tabulated_invalidations(;
+using SnoopCompile
+report_invalidations(;
     job_name = "MyWork",
     invalidations,
 )
-
-import PrettyTables
-PrettyTables.pretty_table(
-    table_data;
-    header,
-    formatters = PrettyTables.ft_printf("%s", 2:2),
-    header_crayon = PrettyTables.crayon"yellow bold",
-    subheader_crayon = PrettyTables.crayon"green bold",
-    crop = :none,
-    alignment = [:l, :c, :c, :c],
-)
 ```
+
+Using `report_invalidations` requires that you first load the `PrettyTables.jl` package.
 """
-function tabulated_invalidations(;
-        job_name::String,
-        invalidations,
-        n_rows::Int = 10,
-        process_filename::Function = x -> x,
-    )
-    trees = reverse(invalidation_trees(invalidations))
-    n_total_invalidations = length(uinvalidated(invalidations))
-    # TODO: Merge `@info` statement with one below
-    @info "Number of invalidations for $job_name: $n_total_invalidations"
-    invs_per_method = map(trees) do methinvs
-        countchildren(methinvs)
-    end
-    n_invs_total = length(invs_per_method)
-    truncated_invs = n_rows < n_invs_total
-    sum_invs = sum(invs_per_method)
-    invs_per_method = invs_per_method[1:min(n_rows, n_invs_total)]
-    trees = trees[1:min(n_rows, n_invs_total)]
-    trunc_msg = truncated_invs ? " (showing $n_rows) " : ""
-    @info "$(job_name): $n_invs_total total method invalidations$trunc_msg"
-    n_invalidations_percent = map(invs_per_method) do inv
-        inv_perc = inv / sum_invs
-        Int(round(inv_perc*100, digits = 0))
-    end
-    meth_name = map(trees) do inv
-        "$(inv.method.name)"
-    end
-    fileinfo = map(trees) do inv
-        "$(process_filename(string(inv.method.file))):$(inv.method.line)"
-    end
-    header = (
-        ["<file name>:<line number>", "Method Name", "Invalidations", "Invalidations %"],
-        ["", "", "Number", "(xᵢ/∑x)"],
-    )
-    table_data = hcat(
-        fileinfo,
-        meth_name,
-        invs_per_method,
-        n_invalidations_percent,
-    )
-    return (; table_data, header)
-end
+function report_invalidations end
 
 """
     trees = invalidation_trees(list)

--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -256,6 +256,89 @@ else
 end
 
 """
+    tabulated_invalidations(;
+        job_name::String,
+        invalidations,
+        n_rows::Int = 10,
+        process_filename::Function = x -> x,
+    )
+
+A NamedTuple, `(; table_data, header)`, which
+contains a condensed form of invalidations in the form
+of a matrix and a header, which can be easily tabulated.
+An `@info` message also prints some information, for example
+if the table has been truncated (upon request).
+
+```julia
+import SnoopCompileCore
+invalidations = SnoopCompileCore.@snoopr begin
+
+    # load packages & do representative work
+
+end;
+
+import SnoopCompile
+(; table_data, header) = SnoopCompile.tabulated_invalidations(;
+    job_name = "MyWork",
+    invalidations,
+)
+
+import PrettyTables
+PrettyTables.pretty_table(
+    table_data;
+    header,
+    formatters = PrettyTables.ft_printf("%s", 2:2),
+    header_crayon = PrettyTables.crayon"yellow bold",
+    subheader_crayon = PrettyTables.crayon"green bold",
+    crop = :none,
+    alignment = [:l, :c, :c, :c],
+)
+```
+"""
+function tabulated_invalidations(;
+        job_name::String,
+        invalidations,
+        n_rows::Int = 10,
+        process_filename::Function = x -> x,
+    )
+    trees = reverse(invalidation_trees(invalidations))
+    n_total_invalidations = length(uinvalidated(invalidations))
+    # TODO: Merge `@info` statement with one below
+    @info "Number of invalidations for $job_name: $n_total_invalidations"
+    invs_per_method = map(trees) do methinvs
+        countchildren(methinvs)
+    end
+    n_invs_total = length(invs_per_method)
+    truncated_invs = n_rows < n_invs_total
+    sum_invs = sum(invs_per_method)
+    invs_per_method = invs_per_method[1:min(n_rows, n_invs_total)]
+    trees = trees[1:min(n_rows, n_invs_total)]
+    trunc_msg = truncated_invs ? " (showing $n_rows) " : ""
+    @info "$(job_name): $n_invs_total total method invalidations$trunc_msg"
+    n_invalidations_percent = map(invs_per_method) do inv
+        inv_perc = inv / sum_invs
+        Int(round(inv_perc*100, digits = 0))
+    end
+    meth_name = map(trees) do inv
+        "$(inv.method.name)"
+    end
+    fileinfo = map(trees) do inv
+        "$(process_filename(string(inv.method.file))):$(inv.method.line)"
+    end
+    header = (
+        ["<file name>:<line number>", "Method Name", "Invalidations", "Invalidations %"],
+        ["", "", "Number", "(xᵢ/∑x)"],
+    )
+    table_data = hcat(
+        fileinfo,
+        meth_name,
+        invs_per_method,
+        n_invalidations_percent,
+    )
+    return (; table_data, header)
+end
+
+"""
     trees = invalidation_trees(list)
 
 Parse `list`, as captured by [`SnoopCompileCore.@snoopr`](@ref), into a set of invalidation trees, where parents nodes

--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -274,7 +274,7 @@ if the table has been truncated (upon request).
 import SnoopCompileCore
 invalidations = SnoopCompileCore.@snoopr begin
 
-    # load packages & do representative work
+    # load packages & define any additional methods
 
 end;
 

--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -257,13 +257,15 @@ end
 
 """
     report_invalidations(;
-        job_name::String,
+        job_name::String = "",
         invalidations,
         n_rows::Int = 10,
         process_filename::Function = x -> x,
     )
 
-Print a tabular summary of invalidations.
+Print a tabular summary of invalidations given:
+
+ - `job_name::String` the name of the job
 
 An `@info` message also prints some information, for example
 if the table has been truncated (upon request).
@@ -277,6 +279,7 @@ invalidations = SnoopCompileCore.@snoopr begin
 end;
 
 using SnoopCompile
+using PrettyTables # to load report_invalidations
 report_invalidations(;
     job_name = "MyWork",
     invalidations,

--- a/src/report_invalidations.jl
+++ b/src/report_invalidations.jl
@@ -1,0 +1,57 @@
+# This file is loaded conditionally via @require if PrettyTables is loaded
+
+import .PrettyTables
+
+export report_invalidations
+
+function report_invalidations(;
+        job_name::String,
+        invalidations,
+        n_rows::Int = 10,
+        process_filename::Function = x -> x,
+    )
+    trees = reverse(invalidation_trees(invalidations))
+    n_total_invalidations = length(uinvalidated(invalidations))
+    # TODO: Merge `@info` statement with one below
+    @info "Number of invalidations for $job_name: $n_total_invalidations"
+    invs_per_method = map(trees) do methinvs
+        countchildren(methinvs)
+    end
+    n_invs_total = length(invs_per_method)
+    truncated_invs = n_rows < n_invs_total
+    sum_invs = sum(invs_per_method)
+    invs_per_method = invs_per_method[1:min(n_rows, n_invs_total)]
+    trees = trees[1:min(n_rows, n_invs_total)]
+    trunc_msg = truncated_invs ? " (showing $n_rows) " : ""
+    @info "$(job_name): $n_invs_total total method invalidations$trunc_msg"
+    n_invalidations_percent = map(invs_per_method) do inv
+        inv_perc = inv / sum_invs
+        Int(round(inv_perc*100, digits = 0))
+    end
+    meth_name = map(trees) do inv
+        "$(inv.method.name)"
+    end
+    fileinfo = map(trees) do inv
+        "$(process_filename(string(inv.method.file))):$(inv.method.line)"
+    end
+    header = (
+        ["<file name>:<line number>", "Method Name", "Invalidations", "Invalidations %"],
+        ["", "", "Number", "(xᵢ/∑x)"],
+    )
+    table_data = hcat(
+        fileinfo,
+        meth_name,
+        invs_per_method,
+        n_invalidations_percent,
+    )
+
+    PrettyTables.pretty_table(
+        table_data;
+        header,
+        formatters = PrettyTables.ft_printf("%s", 2:2),
+        header_crayon = PrettyTables.crayon"yellow bold",
+        subheader_crayon = PrettyTables.crayon"green bold",
+        crop = :none,
+        alignment = [:l, :c, :c, :c],
+    )
+end

--- a/src/report_invalidations.jl
+++ b/src/report_invalidations.jl
@@ -5,7 +5,7 @@ import .PrettyTables
 export report_invalidations
 
 function report_invalidations(;
-        job_name::String,
+        job_name::String = "",
         invalidations,
         n_rows::Int = 10,
         process_filename::Function = x -> x,
@@ -13,7 +13,6 @@ function report_invalidations(;
     trees = reverse(invalidation_trees(invalidations))
     n_total_invalidations = length(uinvalidated(invalidations))
     # TODO: Merge `@info` statement with one below
-    @info "Number of invalidations for $job_name: $n_total_invalidations"
     invs_per_method = map(trees) do methinvs
         countchildren(methinvs)
     end
@@ -22,8 +21,9 @@ function report_invalidations(;
     sum_invs = sum(invs_per_method)
     invs_per_method = invs_per_method[1:min(n_rows, n_invs_total)]
     trees = trees[1:min(n_rows, n_invs_total)]
-    trunc_msg = truncated_invs ? " (showing $n_rows) " : ""
-    @info "$(job_name): $n_invs_total total method invalidations$trunc_msg"
+    trunc_msg = truncated_invs ? " (showing $n_rows functions) " : ""
+    mgs_prefix = job_name == "" ? "" : "$job_name: "
+    @info "$mgs_prefix$n_total_invalidations methods invalidated for $n_invs_total functions$trunc_msg"
     n_invalidations_percent = map(invs_per_method) do inv
         inv_perc = inv / sum_invs
         Int(round(inv_perc*100, digits = 0))
@@ -35,8 +35,8 @@ function report_invalidations(;
         "$(process_filename(string(inv.method.file))):$(inv.method.line)"
     end
     header = (
-        ["<file name>:<line number>", "Method Name", "Invalidations", "Invalidations %"],
-        ["", "", "Number", "(xᵢ/∑x)"],
+        ["<file name>:<line number>", "Function Name", "Invalidations", "Invalidations %"],
+        ["", "", "", "(xᵢ/∑x)"],
     )
     table_data = hcat(
         fileinfo,

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -1,4 +1,5 @@
 using SnoopCompile, InteractiveUtils, MethodAnalysis, Pkg, Test
+import PrettyTables
 
 const qualify_mi = Base.VERSION >= v"1.7.0-DEV.5"  # julia PR #38608
 
@@ -187,6 +188,23 @@ end
             Base.@irrational twoπ 6.2831853071795864769 2*big(π)
         end
     end
+
+    # Tabulate invalidations:
+    (; table_data, header) = SnoopCompile.tabulated_invalidations(;
+        job_name = "job_name",
+        invalidations = invs,
+        process_filename = x -> "SnoopCompile.jl"*last(split(x, basename(pkgdir(SnoopCompile)))),
+    )
+    PrettyTables.pretty_table(
+        table_data;
+        header,
+        formatters = PrettyTables.ft_printf("%s", 2:2),
+        header_crayon = PrettyTables.crayon"yellow bold",
+        subheader_crayon = PrettyTables.crayon"green bold",
+        crop = :none,
+        alignment = [:l, :c, :c, :c],
+    )
+
     trees = invalidation_trees(invs)
     @test length(trees) == 3
     io = IOBuffer()

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -1,5 +1,5 @@
 using SnoopCompile, InteractiveUtils, MethodAnalysis, Pkg, Test
-import PrettyTables
+import PrettyTables # so that the report_invalidations.jl file is loaded
 
 const qualify_mi = Base.VERSION >= v"1.7.0-DEV.5"  # julia PR #38608
 
@@ -190,19 +190,10 @@ end
     end
 
     # Tabulate invalidations:
-    (; table_data, header) = SnoopCompile.tabulated_invalidations(;
+    # Note: this table may change over time as invalidations get fixed.
+    SnoopCompile.report_invalidations(;
         job_name = "job_name",
         invalidations = invs,
-        process_filename = x -> "SnoopCompile.jl"*last(split(x, basename(pkgdir(SnoopCompile)))),
-    )
-    PrettyTables.pretty_table(
-        table_data;
-        header,
-        formatters = PrettyTables.ft_printf("%s", 2:2),
-        header_crayon = PrettyTables.crayon"yellow bold",
-        subheader_crayon = PrettyTables.crayon"green bold",
-        crop = :none,
-        alignment = [:l, :c, :c, :c],
     )
 
     trees = invalidation_trees(invs)

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -188,13 +188,13 @@ end
             Base.@irrational twoπ 6.2831853071795864769 2*big(π)
         end
     end
-
     # Tabulate invalidations:
-    # Note: this table may change over time as invalidations get fixed.
-    SnoopCompile.report_invalidations(;
-        job_name = "job_name",
+    io = IOBuffer()
+    SnoopCompile.report_invalidations(io;
         invalidations = invs,
     )
+    str = String(take!(io))
+    @test occursin("Invalidations %", str)
 
     trees = invalidation_trees(invs)
     @test length(trees) == 3


### PR DESCRIPTION
Hello 👋🏻! There has been a lot of activity around hunting down invalidations lately, for example:

 - [julia-invalidations](https://github.com/julia-actions/julia-invalidations)
 - [discourse thread](https://discourse.julialang.org/t/potential-performance-regressions-in-julia-1-8-for-special-un-precompiled-type-dispatches-and-how-to-fix-them/86359)
 - [SciML issue](https://github.com/SciML/DifferentialEquations.jl/issues/786)

As mentioned in [this comment](https://discourse.julialang.org/t/potential-performance-regressions-in-julia-1-8-for-special-un-precompiled-type-dispatches-and-how-to-fix-them/86359/21) of the `discourse thread`, I've added a function called `report_invalidations` to [ReportMetrics.jl](https://github.com/CliMA/ReportMetrics.jl) which summarizes the output of `SnoopCompileCore.@snoopr` with quantitative and actionable information.

I'd like to call this function from the `julia-invalidations` github action. I thought it might be cleaner to add this functionality to SnoopCompile directly (rather than a separate package) since it's relatively light weight (barring PrettyTables) and uses SnoopCompile internals.

The `ReportMetrics.jl` version of the printed table looks like this:
```
[ Info: Number of invalidations for SomeWork: 7
[ Info: SomeWork: 6 total method invalidations
┌───────────────────────────────────┬─────────────┬───────────────┬─────────────────┐
│ <file name>:<line number>         │ Method Name │ Invalidations │ Invalidations % │
│                                   │             │    Number     │     (xᵢ/∑x)     │
├───────────────────────────────────┼─────────────┼───────────────┼─────────────────┤
│ SnoopCompile.jlirrationals.jl:182 │  BigFloat   │       1       │       50        │
│ SnoopCompile.jlirrationals.jl:182 │  BigFloat   │       1       │       50        │
│ SnoopCompile.jlirrationals.jl:192 │   Float32   │       0       │        0        │
│ SnoopCompile.jlirrationals.jl:191 │   Float64   │       0       │        0        │
│ SnoopCompile.jlirrationals.jl:192 │   Float32   │       0       │        0        │
│ SnoopCompile.jlirrationals.jl:191 │   Float64   │       0       │        0        │
└───────────────────────────────────┴─────────────┴───────────────┴─────────────────┘
```
