### PR TITLE
Update invalidation logging format

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompile"
 uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "2.9.4"
+version = "2.9.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/SnoopPrecompile/test/runtests.jl
+++ b/SnoopPrecompile/test/runtests.jl
@@ -47,6 +47,6 @@ using UUIDs
         end
         close(pipe.in)
         str = read(pipe.out, String)
-        @test occursin("UndefVarError: missing_function not defined", str)
+        @test occursin(r"UndefVarError: `?missing_function`? not defined", str)
     end
 end


### PR DESCRIPTION
This updates to the logging format used by the most recent nightly build
of Julia (1.9). While there has been a lot of churn in this area, there
are reasons to hope that we're entering a period of stability: there are
no known "holes" in our coverage after resolving the `invoke` issues
(https://github.com/JuliaLang/julia/pull/46010 and fixup PRs that came
later), and the subsequent major rewrite of the invalidation logic
(https://github.com/JuliaLang/julia/pull/46920) suggests this format may
have some durability.

CC @vtjnash