### PR TITLE
revert broken commit - add test

### DIFF
--- a/SnoopPrecompile/src/SnoopPrecompile.jl
+++ b/SnoopPrecompile/src/SnoopPrecompile.jl
@@ -60,11 +60,10 @@ macro precompile_all_calls(ex::Expr)
     end
     if have_inference_tracking
         ex = quote
-            thunk() = $ex
             Core.Compiler.Timings.reset_timings()
             Core.Compiler.__set_measure_typeinf(true)
             try
-                Base.invokelatest(thunk)
+                $ex
             finally
                 Core.Compiler.__set_measure_typeinf(false)
                 Core.Compiler.Timings.close_current_timer()
@@ -105,11 +104,11 @@ to your package).
 """
 macro precompile_setup(ex::Expr)
     return esc(quote
-        let
+        # let
             if ccall(:jl_generating_output, Cint, ()) == 1 || $SnoopPrecompile.verbose[]
                 $ex
             end
-        end
+        # end
     end)
 end
 

--- a/SnoopPrecompile/src/SnoopPrecompile.jl
+++ b/SnoopPrecompile/src/SnoopPrecompile.jl
@@ -73,9 +73,7 @@ macro precompile_all_calls(ex::Expr)
     end
     return esc(quote
         if ccall(:jl_generating_output, Cint, ()) == 1 || $SnoopPrecompile.verbose[]
-            let
-                $ex
-            end
+            $ex
         end
     end)
 end

--- a/SnoopPrecompile/test/SnoopPC_C/Project.toml
+++ b/SnoopPrecompile/test/SnoopPC_C/Project.toml
@@ -1,0 +1,7 @@
+name = "SnoopPC_C"
+uuid = "e6c49816-f2a1-47f5-8743-1735c486fd91"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"

--- a/SnoopPrecompile/test/SnoopPC_C/src/SnoopPC_C.jl
+++ b/SnoopPrecompile/test/SnoopPC_C/src/SnoopPC_C.jl
@@ -1,0 +1,32 @@
+module SnoopPC_C
+
+using SnoopPrecompile
+
+# mimic `RecipesBase` code - see github.com/JuliaPlots/Plots.jl/issues/4597 and #317
+module RB
+    export @recipe
+
+    apply_recipe(args...) = nothing
+    macro recipe(ex::Expr)
+        _, func_body = ex.args
+        func = Expr(:call, :($RB.apply_recipe))
+        Expr(
+            :function,
+            func,
+            quote
+                @nospecialize
+                func_return = $func_body
+            end |> esc
+        )
+    end
+end
+using .RB
+
+@precompile_setup begin
+    struct Foo end
+    @precompile_all_calls begin
+        @recipe f(::Foo) = nothing
+    end
+end
+
+end # module SnoopPC_C

--- a/SnoopPrecompile/test/runtests.jl
+++ b/SnoopPrecompile/test/runtests.jl
@@ -50,5 +50,7 @@ using UUIDs
         @test occursin(r"UndefVarError: `?missing_function`? not defined", str)
     end
 
-    using SnoopPC_C
+    if Base.VERSION >= v"1.6"
+        using SnoopPC_C
+    end
 end

--- a/SnoopPrecompile/test/runtests.jl
+++ b/SnoopPrecompile/test/runtests.jl
@@ -49,4 +49,6 @@ using UUIDs
         str = read(pipe.out, String)
         @test occursin(r"UndefVarError: `?missing_function`? not defined", str)
     end
+
+    using SnoopPC_C
 end


### PR DESCRIPTION
@timholy, the added test breaks on `1.0.2` and not on `1.0.1`.

So I've reverted the changes of `1.0.2` and we can start working on a fix.

I'm not sure if the precompilation scenario is valid code in `RecipesBase` (this is clearly a niche involving meta-programming), and I'd be happy to change some - considered invalid - but working statements in https://github.com/JuliaPlots/Plots.jl/blob/master/RecipesBase/src/RecipesBase.jl#L600-L619.