### PR TITLE
Add a copy-paste invalidations analysis script

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -113,7 +113,7 @@ with few children, and thus this shows how many "bad actors" need to be investig
 invalidations, with `show(trees[end-1])` being the second most, and so forth.
 
 ```julia
-using SnoopCompile
+using SnoopCompileCore
 invalidations = @snoopr begin
     # Your code goes here!
     using OrdinaryDiffEq

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -134,7 +134,7 @@ trees = SnoopCompile.invalidation_trees(invalidations);
 
 @show length(SnoopCompile.uinvalidated(invalidations)) # show total invalidations
 
-show(trees[end]) # show the most invalidated method
+show(trees[end]) # show the most invalidating method
 
 # Count number of children (number of invalidations per invalidated method)
 n_invalidations = map(trees) do methinvs

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -6,8 +6,11 @@ You can find a more expansive version of this page in [this blog post](https://j
 
 ## Cut to the Chase: A copy-paste analysis of invalidations
 
-The following is a quick "grab and go" script for analyzing invalidations. Insert your code into the `@snoopr` block. The resulting plot shows the
-distributions of the invalidations sorted by the number of children affected. Generally, invalidations with many children matter more than those
+The following is a quick "grab and go" script for analyzing invalidations.
+Insert package loads (`using` or `import` statements) and/or method definitions into the `@snoopr` block,
+and put the workload you want to be fast in the `@snoopi_deep` block.
+The resulting plot shows the distribution of the invalidations sorted by the number of children affected.
+Generally, invalidations with many children matter more than those
 with few children, and thus this shows how many "bad actors" need to be investigated. `show(trees[end])` show the method which leads to the most
 invalidations, with `show(trees[end-1])` being the second most, and so forth.
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -18,11 +18,11 @@ While the plot shows total invalidations (`trees`), only the ones in `staletrees
 ```julia
 using SnoopCompileCore
 invalidations = @snoopr using PkgA, PkgB;
-using SnoopCompile
-trees = invalidation_trees(invalidations)
 tinf = @snoopi_deep begin
     some_workload()
 end
+using SnoopCompile
+trees = invalidation_trees(invalidations)
 staletrees = precompile_blockers(trees, tinf)
 
 @show length(SnoopCompile.uinvalidated(invalidations)) # show total invalidations

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -115,19 +115,8 @@ invalidations, with `show(trees[end-1])` being the second most, and so forth.
 ```julia
 using SnoopCompileCore
 invalidations = @snoopr begin
-    # Your code goes here!
+    # Your packages go here!
     using OrdinaryDiffEq
-
-    function lorenz(du, u, p, t)
-        du[1] = 10.0(u[2] - u[1])
-        du[2] = u[1] * (28.0 - u[3]) - u[2]
-        du[3] = u[1] * u[2] - (8 / 3) * u[3]
-    end
-    u0 = [1.0; 0.0; 0.0]
-    tspan = (0.0, 100.0)
-    prob = ODEProblem{true,false}(lorenz, u0, tspan)
-    alg = Rodas5()
-    tinf = solve(prob, alg)
 end;
 
 trees = SnoopCompile.invalidation_trees(invalidations);

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -26,9 +26,7 @@ staletrees = precompile_blockers(trees, tinf)
 show(trees[end]) # show the most invalidating method
 
 # Count number of children (number of invalidations per invalidated method)
-n_invalidations = map(trees) do methinvs
-    SnoopCompile.countchildren(methinvs)
-end
+n_invalidations = map(SnoopCompile.countchildren, trees)
 
 import Plots
 Plots.plot(

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -108,7 +108,7 @@ If we create `c32 = [1.0f0]` and then `calldouble2(c32)`, we would also see back
 ## A copy-paste analysis of invalidations
 
 The following is a quick "grab and go" script for analyzing invalidations. Insert your code into the `@snoopr` block. The resulting plot shows the
-distributions of the invalidations sorted by the number of children effected. Generally, invalidations with many children matter more than those
+distributions of the invalidations sorted by the number of children affected. Generally, invalidations with many children matter more than those
 with few children, and thus this shows how many "bad actors" need to be investigated. `show(trees[end])` show the method which leads to the most
 invalidations, with `show(trees[end-1])` being the second most, and so forth.
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -13,6 +13,7 @@ The resulting plot shows the distribution of the invalidations sorted by the num
 Generally, invalidations with many children matter more than those
 with few children, and thus this shows how many "bad actors" need to be investigated. `show(trees[end])` show the method which leads to the most
 invalidations, with `show(trees[end-1])` being the second most, and so forth.
+While the plot shows total invalidations (`trees`), only the ones in `staletrees` affect the workload in `@snoopi_deep`.
 
 ```julia
 using SnoopCompileCore


### PR DESCRIPTION
As much as details are nice, sometimes giving something that's easy to copy/repeat is good. Maybe this could be added as a library function (it probably would need to be a macro).