### PR TITLE
Fix a hang in `uinvalidated`

### DIFF
--- a/docs/src/jet.md
+++ b/docs/src/jet.md
@@ -18,7 +18,7 @@ We can demonstrate both the need and use of these tools with a simple extended e
 
 JET provides a useful report for the following call:
 
-```jldoctest jet; filter=r"@ reduce.*"
+```jldoctest jet; filter=[r"@ reduce.*", r"(in|@)", r"(REPL\[\d+\]|none)"]
 julia> using JET
 
 julia> list = Any[1,2,3];
@@ -78,7 +78,7 @@ julia> callsum(lc)
 6
 
 julia> @report_call callsum(lc)
-No errors !
+No errors detected
 ```
 
 Because we "hid" the type of `list` from inference, JET couldn't tell what specific instance of `sum` was going to be called, so it was unable to detect any errors.

--- a/docs/src/snoopr.md
+++ b/docs/src/snoopr.md
@@ -33,7 +33,7 @@ Readers who want more background and context are encouraged to read [this blog p
 ## Recording invalidations
 
 ```@meta
-DocTestFilters = r"(REPL\[\d+\]|none):\d+"
+DocTestFilters = r"(in|@) [a-zA-Z0-9]* (REPL\[\d+\]|none):\d+"
 DocTestSetup = quote
     using SnoopCompile
 end
@@ -115,7 +115,7 @@ The length of this set is your simplest insight into the extent of invalidations
 If you want to fix invalidations, it's crucial to know *why* certain `MethodInstance`s were invalidated.
 For that, it's best to use a tree structure, in which children are invalidated because their parents get invalidated:
 
-```jldoctest invalidations
+```jldoctest invalidations; filter=[r"(in Main at|@ Main) (REPL\[\d+\]|none)"]
 julia> trees = invalidation_trees(invalidations)
 1-element Vector{SnoopCompile.MethodInvalidations}:
  inserting f(::Float64) in Main at REPL[9]:1 invalidated:
@@ -165,7 +165,7 @@ These are invalidations triggered via the `MethodTable` for a particular functio
 When extracting `mt_backedges`, in addition to a root `MethodInstance` these also indicate a particular signature that triggered the invalidation.
 We can illustrate this by returning to the `call2f` example above:
 
-```jldoctest invalidations
+```jldoctest invalidations; filter=[r"(in Main at|@ Main) (REPL\[\d+\]|none)"]
 julia> call2f(["hello"])
 ERROR: MethodError: no method matching f(::String)
 [...]

--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -26,12 +26,15 @@ function uinvalidated(invlist; exclude_corecompiler::Bool=true)
         item = invlist[i]
         if isa(item, Core.MethodInstance)
             if i < lastindex(invlist)
-                invlist[i+1] == "invalidate_mt_cache" && continue
+                if invlist[i+1] == "invalidate_mt_cache"
+                    i += 2
+                    continue
+                end
                 if invlist[i+1] == "verify_methods"
                     # Skip over the cause, which can also be a MethodInstance
                     # These may be superseded, but they aren't technically invalidated
                     # (e.g., could still be called via `invoke`)
-                    i += 1
+                    i += 2
                 end
             end
             if !exclude_corecompiler || !from_corecompiler(item)

--- a/src/parcel_snoopc.jl
+++ b/src/parcel_snoopc.jl
@@ -203,7 +203,7 @@ julia> pcstatements = ["precompile(sum, (Vector{Int},))", "precompile(sum, (Cust
 
 julia> SnoopCompile.remove_if_not_eval!(pcstatements, Base)
 ┌ Warning: Faulty precompile statement: precompile(sum, (CustomVector{Int},))
-│   exception = UndefVarError: CustomVector not defined
+│   exception = UndefVarError: `CustomVector` not defined
 └ @ Base precompile_Base.jl:375
 1-element Vector{String}:
  "precompile(sum, (Vector{Int},))"

--- a/src/parcel_snoopi_deep.jl
+++ b/src/parcel_snoopi_deep.jl
@@ -149,7 +149,7 @@ that it is being inferred for many specializations (which might include speciali
 
 We'll use [`SnoopCompile.flatten_demo`](@ref), which runs `@snoopi_deep` on a workload designed to yield reproducible results:
 
-```jldoctest accum1; setup=:(using SnoopCompile), filter=r"([0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?|at .*/deep_demos.jl:\\d+|at Base\\.jl:\\d+|at compiler/typeinfer\\.jl:\\d+|WARNING: replacing module FlattenDemo\\.\\n)"
+```jldoctest accum1; setup=:(using SnoopCompile), filter=[r"(in|@)", r"([0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?|:[0-9]+\\)|at .*/deep_demos.jl:\\d+|at Base\\.jl:\\d+|at compiler/typeinfer\\.jl:\\d+|WARNING: replacing module FlattenDemo\\.\\n)"]
 julia> tinf = SnoopCompile.flatten_demo()
 InferenceTimingNode: 0.002148974/0.002767166 on Core.Compiler.Timings.ROOT() with 1 direct children
 
@@ -918,7 +918,7 @@ Filter `itrigs` for those with a non-passing `JET` report, returning the list of
 
 # Examples
 
-```jldoctest jetfib; setup=(using SnoopCompile, JET), filter=r"[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?/[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?"
+```jldoctest jetfib; setup=(using SnoopCompile, JET), filter=[r"\\d direct children", r"[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?/[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?"]
 julia> fib(n::Integer) = n ≤ 2 ? n : fib(n-1) + fib(n-2);
 
 julia> function fib(str::String)
@@ -938,7 +938,7 @@ julia> tinf = @snoopi_deep try mapfib(list) catch end
 InferenceTimingNode: 0.049825/0.071476 on Core.Compiler.Timings.ROOT() with 5 direct children
 
 julia> @report_call mapfib(list)
-No errors !
+No errors detected
 ```
 
 JET did not catch the error because the call to `fib` is hidden behind runtime dispatch.
@@ -949,7 +949,7 @@ julia> report_callees(inference_triggers(tinf))
 1-element Vector{Pair{InferenceTrigger, JET.JETCallResult{JET.JETAnalyzer{JET.BasicPass{typeof(JET.basic_function_filter)}}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}}}}:
  Inference triggered to call fib(::String) from iterate (./generator.jl:47) inlined into Base.collect_to!(::Vector{Int64}, ::Base.Generator{Vector{Any}, typeof(fib)}, ::Int64, ::Int64) (./array.jl:782) => ═════ 1 possible error found ═════
 ┌ @ none:3 fib(m)
-│ variable m is not defined: fib(m)
+│ variable `m` is not defined
 └──────────
 ```
 """

--- a/test/snoopr.jl
+++ b/test/snoopr.jl
@@ -54,6 +54,8 @@ end
     mi2 = methodinstance(SnooprTests.callapplyf, (Vector{Any},))
 
     @test length(uinvalidated([mi1])) == 1  # issue #327
+    @test length(uinvalidated([mi1, "verify_methods", mi2])) == 1
+    @test length(uinvalidated([mi1, "invalidate_mt_cache"])) == 0
 
     invs = @snoopr SnooprTests.f(::AbstractFloat) = 3
     @test !isempty(invs)


### PR DESCRIPTION
Picked up as the source of hanging in the doctests. Also updates doctests to reduce the number of errors.