### PR TITLE
Fix snoopc test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,11 @@ logfile = joinpath(tempdir(), "anon.log")
 end
 data = SnoopCompile.read(logfile)
 pc = SnoopCompile.parcel(reverse!(data[2]))
-@test length(pc[:Base]) <= 1
+if Base.VERSION < v"1.10"
+    @test length(pc[:Base]) <= 1
+else
+    @test !haskey(pc, :Base)
+end
 
 # issue #29
 keep, pcstring, topmod, name = SnoopCompile.parse_call("Tuple{getfield(JLD, Symbol(\"##s27#8\")), Any, Any, Any, Any, Any}")


### PR DESCRIPTION
With Julia 1.6, a precompile statement is generated:

```julia
julia> using SnoopCompile

julia> logfile = joinpath(tempdir(), "anon.log")
"/tmp/anon.log"

julia> @snoopc logfile begin
           map(x->x^2, [1,2,3])
       end
Launching new julia process to run commands...
done.

julia> data = SnoopCompile.read(logfile)
(UInt64[0x00000000003d57dc, 0x00000000003d590b, 0x00000000016f8738], ["Tuple{Type{Base.Generator{I, F} where F where I}, Main.var\"#1#2\", Array{Int64, 1}}", "Tuple{typeof(Base.map), Function, Array{Int64, 1}}", "Tuple{typeof(Base.collect_similar), Array{Int64, 1}, Base.Generator{Array{Int64, 1}, Main.var\"#1#2\"}}"])

julia> read(logfile, String) |> println
4020491	"Tuple{typeof(Base.map), Function, Array{Int64, 1}}"
4020188	"Tuple{Type{Base.Generator{I, F} where F where I}, Main.var"#1#2", Array{Int64, 1}}"
24086328	"Tuple{typeof(Base.collect_similar), Array{Int64, 1}, Base.Generator{Array{Int64, 1}, Main.var"#1#2"}}"


julia> pc = SnoopCompile.parcel(reverse!(data[2]))
Dict{Symbol, Vector{String}} with 1 entry:
  :Base => ["precompile(Tuple{typeof(Base.map), typeof(identity), Array{Int64, 1}})"]
```

With Julia 1.10, the new precompile statement is not generated:

```julia
julia> using SnoopCompile

julia> logfile = joinpath(tempdir(), "anon.log")
"/tmp/anon.log"

julia> @snoopc logfile begin
           map(x->x^2, [1,2,3])
       end
Launching new julia process to run commands...
done.

julia> data = SnoopCompile.read(logfile)
(UInt64[0x00000000003bc942, 0x00000000013bae2e], ["Tuple{Type{Base.Generator{I, F} where F where I}, Main.var\"#1#2\", Array{Int64, 1}}", "Tuple{typeof(Base.collect_similar), Array{Int64, 1}, Base.Generator{Array{Int64, 1}, Main.var\"#1#2\"}}"])

julia> read(logfile, String) |> println
3918146	"Tuple{Type{Base.Generator{I, F} where F where I}, Main.var"#1#2", Array{Int64, 1}}"
20688430	"Tuple{typeof(Base.collect_similar), Array{Int64, 1}, Base.Generator{Array{Int64, 1}, Main.var"#1#2"}}"


julia> pc = SnoopCompile.parcel(reverse!(data[2]))
Dict{Symbol, Vector{String}}()
```