### PR TITLE
Fix SCPyPlotExt

### DIFF
--- a/docs/src/tutorials/pgdsgui.md
+++ b/docs/src/tutorials/pgdsgui.md
@@ -26,7 +26,7 @@ Again, this seems appropriate for a language where specialization typically happ
 
 We'll add these packages to your [default environment](https://pkgdocs.julialang.org/v1/environments/) so you can use them while in the package environment:
 
-```
+```julia
 using Pkg
 Pkg.add(["SnoopCompileCore", "SnoopCompile", "PyPlot"]);
 ```
@@ -84,7 +84,7 @@ julia> tinf = @snoop_inference mappushes(spelltype, Ts);
 
 Then, *in the same session*, profile the runtime:
 
-```
+```julia
 julia> using Profile
 
 julia> @profile mappushes(spelltype, Ts);

--- a/ext/SCPyPlotExt.jl
+++ b/ext/SCPyPlotExt.jl
@@ -1,5 +1,7 @@
 module SCPyPlotExt
 
+import Profile
+
 using SnoopCompile
 using SnoopCompile: MethodLoc, InferenceTimingNode, PGDSData, lookups
 using PyPlot: PyPlot, plt, PyCall
@@ -7,7 +9,7 @@ using PyPlot: PyPlot, plt, PyCall
 get_bystr(@nospecialize(by)) = by === inclusive ? "Inclusive" :
                                by === exclusive ? "Exclusive" : error("unknown ", by)
 
-function pgdsgui(ax::PyCall.PyObject, ridata::AbstractVector{Pair{Union{Method,MethodLoc},PGDSData}}; bystr, consts, markersz=25, linewidth=0.5, t0 = 0.001, interactive::Bool=true, kwargs...)
+function SnoopCompile.pgdsgui(ax::PyCall.PyObject, ridata::AbstractVector{Pair{Union{Method,MethodLoc},PGDSData}}; bystr, consts, markersz=25, linewidth=0.5, t0 = 0.001, interactive::Bool=true, kwargs...)
     methodref = Ref{Union{Method,MethodLoc}}()   # returned to the user for inspection of clicked methods
     function onclick(event)
         xc, yc = event.xdata, event.ydata
@@ -48,17 +50,17 @@ function pgdsgui(ax::PyCall.PyObject, ridata::AbstractVector{Pair{Union{Method,M
     return methodref
 end
 
-function pgdsgui(ax::PyCall.PyObject, args...; consts::Bool=true, by=inclusive, kwargs...)
+function SnoopCompile.pgdsgui(ax::PyCall.PyObject, args...; consts::Bool=true, by=inclusive, kwargs...)
     pgdsgui(ax, prep_ri(args...; consts, by, kwargs...); bystr=get_bystr(by), consts, kwargs...)
 end
 
-function pgdsgui(args...; kwargs...)
+function SnoopCompile.pgdsgui(args...; kwargs...)
     fig, ax = plt.subplots()
     pgdsgui(ax, args...; kwargs...), ax
 end
 
 function prep_ri(tinf::InferenceTimingNode, pdata=Profile.fetch(); lidict=lookups, consts, by, kwargs...)
-    lookup_firstip!(lookups, pdata)
+    SnoopCompile.lookup_firstip!(lookups, pdata)
     return runtime_inferencetime(tinf, pdata; lidict, consts, by)
 end
 

--- a/ext/SCPyPlotExt.jl
+++ b/ext/SCPyPlotExt.jl
@@ -61,7 +61,7 @@ end
 
 function prep_ri(tinf::InferenceTimingNode, pdata=Profile.fetch(); lidict=lookups, consts, by, kwargs...)
     SnoopCompile.lookup_firstip!(lookups, pdata)
-    return runtime_inferencetime(tinf, pdata; lidict, consts, by)
+    return SnoopCompile.runtime_inferencetime(tinf, pdata; lidict, consts, by)
 end
 
 end

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -105,7 +105,7 @@ that method.
 `ax` is the pyplot axis of the scatterplot.
 
 !!! compat
-    `pgdsgui` depends on PyPlot via the Requires.jl package. You must load both SnoopCompile and PyPlot for this function to be defined.
+    `pgdsgui` depends on PyPlot via Julia extensions. You must load both SnoopCompile and PyPlot for this function to be defined.
 """
 function pgdsgui end
 export pgdsgui


### PR DESCRIPTION
The `SCPyPlotExt` had three problems:

- the default argument to `pdata` is `Profile.fetch()`, but `Profile` was not imported
- the extension was not adding methods to `SnoopCompile.pgdsgui`
- `prep_ri` was failing with `UndefVarError: lookup_firstip! not defined`

As a result, the tutorial on `pgdsgui` was broken.

This commit fixes these issues. In the process, I also fixed syntax highlighing in a couple of places in the documentation.
