### PR TITLE
llvm parsing: filter out `nothing`

### DIFF
--- a/docs/src/tutorials/snoop_llvm.md
+++ b/docs/src/tutorials/snoop_llvm.md
@@ -25,7 +25,7 @@ using SnoopCompileCore
 end
 
 using SnoopCompile
-times, info = SnoopCompile.read_snoop_llvm("func_names.csv", "llvm_timings.yaml", tmin_secs = 0.025);
+times, info = SnoopCompile.read_snoop_llvm("func_names.csv", "llvm_timings.yaml", tmin_secs = 0.005);
 ```
 
 This will write two files, `"func_names.csv"` and `"llvm_timings.yaml"`, in your current working directory. Let's look at what was read from these files:

--- a/src/parcel_snoop_llvm.jl
+++ b/src/parcel_snoop_llvm.jl
@@ -38,11 +38,15 @@ Dict{String, NamedTuple{(:before, :after), Tuple{NamedTuple{(:instructions, :bas
 function read_snoop_llvm(func_csv_file, llvm_yaml_file; tmin_secs=0.0)
     func_csv = _read_snoop_llvm_csv(func_csv_file)
     llvm_yaml = YAML.load_file(llvm_yaml_file)
+    filter!(llvm_yaml) do llvm_module
+        llvm_module["before"] !== nothing
+    end
 
     jl_names = Dict(r[1]::String => r[2]::String for r in func_csv)
 
+    # `get`, but with a warning
     try_get_jl_name(name) = if name in keys(jl_names)
-        jl_names[name]
+            jl_names[name]
         else
             @warn "Couldn't find $name"
             name


### PR DESCRIPTION
Some of the `Dicts` in `llvm_yaml` had entries `"before" => nothing`,
and that was breaking parsing.

Fixes #405