### PR TITLE
Add option to make write more git diff-friendly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SnoopCompile"
 uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
 author = ["Tim Holy <tim.holy@gmail.com>", "Shuhei Kadowaki <aviatesk@gmail.com>"]
-version = "3.0.3"
+version = "3.1.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/write.jl
+++ b/src/write.jl
@@ -32,14 +32,6 @@ function write(filename::AbstractString, pc::Vector; kwargs...)
     end
 end
 
-"""
-    write(prefix::AbstractString, pc::Dict; always::Bool = false)
-
-Write each modules' precompiles to a separate file.  If `always` is
-true, the generated function will always run the precompile statements
-when called, otherwise the statements will only be called during
-package precompilation.
-"""
 function write(prefix::AbstractString, pc::Dict; always::Bool = false)
     if !isdir(prefix)
         mkpath(prefix)
@@ -59,3 +51,18 @@ function write(prefix::AbstractString, pc::Dict; always::Bool = false)
         end
     end
 end
+
+@doc """
+    write(prefix::AbstractString, pc; always::Bool=false, suppress_time::Bool=false)
+
+Write each modules' precompiles to a separate file.  If `always` is true, the
+generated function will always run the precompile statements when called,
+otherwise the statements will only be called during package precompilation.
+
+When writing results from parceling `@snoop_inference`, by default SnoopCompile
+appends the time taken to precompile each statement to the generated file.  If
+`suppress_time` is true, this information will be omitted.
+
+!!! compat "SnoopCompile 3.1"
+    The `suppress_time` keyword argument was added in SnoopCompile 3.1.
+""" write

--- a/test/snoop_inference.jl
+++ b/test/snoop_inference.jl
@@ -748,6 +748,12 @@ include("testmodules/SnoopBench.jl")
     str = String(take!(io))
     @test occursin(r"typeof\(mappushes\),Any,Vector\{A\}", str)
     @test occursin(r"typeof\(mappushes!\),typeof\(identity\),Vector\{Any\},Vector\{A\}", str)
+    @test occursin(r"# time: \d", str)
+    SnoopCompile.write(io, tmis; tmin=0.0, suppress_time=true)
+    str = String(take!(io))
+    @test occursin(r"typeof\(mappushes\),Any,Vector\{A\}", str)
+    @test occursin(r"typeof\(mappushes!\),typeof\(identity\),Vector\{Any\},Vector\{A\}", str)
+    @test !occursin(r"# time: \d", str)
 
     list = Any[1, 1.0, Float16(1.0), a]
     tinf = @snoop_inference SnoopBench.mappushes(isequal(Int8(1)), list)


### PR DESCRIPTION
`SnoopCompile.write(filename, data; suppress_time=true)` now omits the
timing information. Closes #314.

~~If #413 can be resolved quickly, it would be ideal to make another 3.0.x release before merging this.~~ nvm, that ended up being a test-only fix.