### PR TITLE
Update `@snoop_inference` for Julia 1.12

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1'
+          version: 'min'
       - run: julia --project -e 'using Pkg; Pkg.develop([PackageSpec(path=joinpath(pwd(), "SnoopCompileCore"))])'
       - uses: julia-actions/julia-buildpkg@latest
       # To access the developer tools from within a package's environment, they should be in the default environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - run: julia  --check-bounds=yes --project -e 'using Pkg; Pkg.test(; test_args=["cthulhu"], coverage=true)'
+      - run: julia  --check-bounds=yes --project -e 'using Pkg; Pkg.test(; test_args=["jet"], coverage=true)'
+        continue-on-error: true   # JET test is non-fatal
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,SnoopCompileCore/src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       # - run: julia --project -e 'using Pkg; Pkg.develop([PackageSpec(path="SnoopCompileCore")])'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: false    # FIXME: this is very sad, but coverage changes the snoop_inference.jl/Stale tests (as of Julia 1.13.0-DEV.1058)
       - run: julia  --check-bounds=yes --project -e 'using Pkg; Pkg.test(; test_args=["cthulhu"], coverage=true)'
       - run: julia  --check-bounds=yes --project -e 'using Pkg; Pkg.test(; test_args=["jet"], coverage=true)'
         continue-on-error: true   # JET test is non-fatal

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ author = ["Tim Holy <tim.holy@gmail.com>", "Shuhei Kadowaki <aviatesk@gmail.com>
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -31,6 +32,7 @@ SCPyPlotExt = "PyPlot"
 
 [compat]
 AbstractTrees = "0.4"
+CodeTracking = "1.3.9"
 Cthulhu = "2"
 FlameGraphs = "1"
 InteractiveUtils = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ SCPyPlotExt = "PyPlot"
 
 [compat]
 AbstractTrees = "0.4"
-CodeTracking = "1.3.9"
+CodeTracking = "1.3.9, 2"
 Cthulhu = "2"
 FlameGraphs = "1"
 InteractiveUtils = "1"

--- a/SnoopCompileCore/src/SnoopCompileCore.jl
+++ b/SnoopCompileCore/src/SnoopCompileCore.jl
@@ -1,6 +1,6 @@
 module SnoopCompileCore
 
-using Core: MethodInstance, CodeInfo
+using Core: MethodInstance, CodeInstance, CodeInfo
 
 const ReinferUtils = isdefined(Base, :ReinferUtils) ? Base.ReinferUtils : Base.StaticData
 

--- a/SnoopCompileCore/src/snoop_inference.jl
+++ b/SnoopCompileCore/src/snoop_inference.jl
@@ -1,100 +1,26 @@
 export @snoop_inference
 
-struct InferenceTiming
-    mi_info::Core.Compiler.Timings.InferenceFrameInfo
-    inclusive_time::Float64
-    exclusive_time::Float64
-end
-"""
-    inclusive(frame)
+const snoop_inference_lock = ReentrantLock()
+const newly_inferred = CodeInstance[]
 
-Return the time spent inferring `frame` and its callees.
-"""
-inclusive(it::InferenceTiming) = it.inclusive_time
-"""
-    exclusive(frame)
-
-Return the time spent inferring `frame`, not including the time needed for any of its callees.
-"""
-exclusive(it::InferenceTiming) = it.exclusive_time
-
-struct InferenceTimingNode
-    mi_timing::InferenceTiming
-    start_time::Float64
-    children::Vector{InferenceTimingNode}
-    bt
-    parent::InferenceTimingNode
-
-    # Root constructor
-    InferenceTimingNode(mi_timing::InferenceTiming, start_time, @nospecialize(bt)) =
-        new(mi_timing, start_time, InferenceTimingNode[], bt)
-    # Child constructor
-    function InferenceTimingNode(mi_timing::InferenceTiming, start_time, @nospecialize(bt), parent::InferenceTimingNode)
-        child = new(mi_timing, start_time, InferenceTimingNode[], bt, parent)
-        push!(parent.children, child)
-        return child
-    end
-end
-inclusive(node::InferenceTimingNode) = inclusive(node.mi_timing)
-exclusive(node::InferenceTimingNode) = exclusive(node.mi_timing)
-InferenceTiming(node::InferenceTimingNode) = node.mi_timing
-
-function InferenceTimingNode(t::Core.Compiler.Timings.Timing)
-    ttree = timingtree(t)
-    it, start_time, ttree_children = ttree::Tuple{InferenceTiming, Float64, Vector{Any}}
-    root = InferenceTimingNode(it, start_time, t.bt)
-    addchildren!(root, t, ttree_children)
-    return root
+function start_tracking()
+    iszero(snoop_inference_lock.reentrancy_cnt) || throw(ConcurrencyViolationError("already tracking inference (cannot nest `@snoop_inference` blocks)"))
+    lock(snoop_inference_lock)
+    empty!(newly_inferred)
+    ccall(:jl_set_newly_inferred, Cvoid, (Any,), newly_inferred)
+    # return ccall(:jl_log_dispatch_backtrace, Any, (Cint,), 1)
+    empty!(Base.dispatch_backtrace)
+    Core.Compiler.collect_dispatch_backtrace[] = true
+    return nothing
 end
 
-# Compute inclusive times and store as a temporary tree.
-# To allow InferenceTimingNode to be both bidirectional and immutable, we need to create parent node before the child nodes.
-# However, each node stores its inclusive time, which can only be computed efficiently from the leaves up (children before parents).
-# This performs the inclusive-time computation, storing the result as a "temporary tree" that can be used during
-# InferenceTimingNode creation (see `addchildren!`).
-function timingtree(t::Core.Compiler.Timings.Timing)
-    time, start_time = t.time/10^9, t.start_time/10^9
-    incl_time = time
-    tchildren = []
-    for child in t.children
-        tchild = timingtree(child)
-        push!(tchildren, tchild)
-        incl_time += inclusive(tchild[1])
-    end
-    return (InferenceTiming(t.mi_info, incl_time, time), start_time, tchildren)
-end
-
-function addchildren!(parent::InferenceTimingNode, t::Core.Compiler.Timings.Timing, ttrees)
-    for (child, ttree) in zip(t.children, ttrees)
-        it, start_time, ttree_children = ttree::Tuple{InferenceTiming, Float64, Vector{Any}}
-        node = InferenceTimingNode(it, start_time, child.bt, parent)
-        addchildren!(node, child, ttree_children)
-    end
-end
-
-function start_deep_timing()
-    Core.Compiler.Timings.reset_timings()
-    Core.Compiler.__set_measure_typeinf(true)
-end
-function stop_deep_timing()
-    Core.Compiler.__set_measure_typeinf(false)
-    Core.Compiler.Timings.close_current_timer()
-end
-
-function finish_snoop_inference()
-    return InferenceTimingNode(Core.Compiler.Timings._timings[1])
-end
-
-function _snoop_inference(cmd::Expr)
-    return quote
-        start_deep_timing()
-        try
-            $(esc(cmd))
-        finally
-            stop_deep_timing()
-        end
-        finish_snoop_inference()
-    end
+function stop_tracking()
+    Base.assert_havelock(snoop_inference_lock)
+    ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing)
+    unlock(snoop_inference_lock)
+    # ccall(:jl_log_dispatch_backtrace, Any, (Cint,), 0)
+    Core.Compiler.collect_dispatch_backtrace[] = false
+    return nothing
 end
 
 """
@@ -134,11 +60,123 @@ julia> tinf = @snoop_inference begin
 ```
 """
 macro snoop_inference(cmd)
-    return _snoop_inference(cmd)
+    return esc(quote
+        local backtrace_log = $(SnoopCompileCore.start_tracking)()
+        try
+            $cmd
+        finally
+            $(SnoopCompileCore.stop_tracking)()
+        end
+        $timingtree($(SnoopCompileCore.newly_inferred), copy(Base.dispatch_backtrace))
+    end)
 end
 
-# These are okay to come at the top-level because we're only measuring inference, and
-# inference results will be cached in a `.ji` file.
-precompile(start_deep_timing, ())
-precompile(stop_deep_timing, ())
-precompile(finish_snoop_inference, ())
+struct InferenceTimingNode
+    ci::CodeInstance
+    children::Vector{InferenceTimingNode}
+    bt
+    parent::InferenceTimingNode
+
+    function InferenceTimingNode(ci::CodeInstance, st) # for creating the root
+        return new(ci, InferenceTimingNode[], st)
+    end
+    function InferenceTimingNode(ci::CodeInstance, st, parent)
+        child = new(ci, InferenceTimingNode[], st, parent)
+        push!(parent.children, child)
+        return child
+    end
+end
+
+function timingtree(cis, backtraces)
+    root = InferenceTimingNode(Core.Compiler.Timings.ROOTmi.cache, nothing)
+    # the cis are added in the order children-before-parents, we need to be able to reverse that
+    # We index on MethodInstance rather than CodeInstance, because constprop can result in a distinct
+    # (and uncached) CodeInstance for the same MethodInstance
+    miidx = Dict([methodinstance(ci) for ci in cis] .=> eachindex(cis))
+    backedges = [Int[] for _ in eachindex(cis)]
+    for (i, ci) in pairs(cis)
+        for e in ci.edges
+            e isa CodeInstance || continue
+            eidx = get(miidx, methodinstance(e), nothing)
+            if eidx !== nothing
+                push!(backedges[eidx], i)
+            end
+        end
+    end
+    # backtraces = Dict{MethodInstance,Any}(backtrace_log[i] => backtrace_log[i+1] for i in 1:2:length(backtrace_log))
+    addchildren!(root, cis, backedges, miidx, backtraces)
+    return root
+end
+
+function addchildren!(parent::InferenceTimingNode, handled::Set{CodeInstance}, miidx)
+    for ci in parent.ci.edges
+        ci isa CodeInstance || continue
+        haskey(miidx, methodinstance(ci)) || continue
+        ci ∈ handled && continue
+        child = InferenceTimingNode(ci, nothing, parent)
+        push!(handled, ci)
+        addchildren!(child, handled, miidx)
+    end
+    return parent
+end
+
+function addchildren!(parent::InferenceTimingNode, cis, backedges, miidx, backtraces)
+    handled = Set{CodeInstance}()
+    for (i, ci) in pairs(cis)
+        ci ∈ handled && continue
+        # Follow the backedges to the root
+        j = i
+        be = ci
+        while true
+            found = false
+            for k in backedges[j]
+                be = cis[k]
+                if be ∉ handled
+                    j = k
+                    found = true
+                    break
+                end
+            end
+            found || break
+        end
+        be ∈ handled && continue
+        # bt1, bt2 = get(backtraces, Core.Compiler.get_ci_mi(be), (nothing, nothing))
+        # child = InferenceTimingNode(be, make_stacktrace(bt1, bt2), parent)
+        child = InferenceTimingNode(be, get(backtraces, be, nothing), parent)
+        push!(handled, be)
+        addchildren!(child, handled, miidx)
+    end
+    return parent
+end
+
+methodinstance(ci::CodeInstance) = Core.Compiler.get_ci_mi(ci)
+
+# make_stacktrace(bt1::Vector{Ptr{Cvoid}}, bt2::Vector{Any}) = Base._reformat_bt(bt1, bt2)
+# make_stacktrace(::Nothing, ::Nothing) = nothing
+
+## API functions
+
+"""
+    inclusive(ci::InferenceTimingNode; include_llvm::Bool=true)
+
+Return the time spent inferring `ci` and its callees.
+If `include_llvm` is true, the LLVM compilation time is added as well.
+"""
+inclusive(ci::CodeInstance; include_llvm::Bool=true) = reinterpret(Float16, ci.time_infer_total) +
+    include_llvm * reinterpret(Float16, ci.time_compile)
+inclusive(node::InferenceTimingNode; kwargs...) = inclusive(node.ci; kwargs...)
+
+"""
+    exclusive(ci::InferenceTimingNode; include_llvm::Bool=true)
+
+Return the time spent inferring `ci`, not including the time needed for any of its callees.
+If `include_llvm` is true, the LLVM compilation time is added.
+"""
+exclusive(ci::CodeInstance; include_llvm::Bool=true) = reinterpret(Float16, ci.time_infer_self) +
+    include_llvm * reinterpret(Float16, ci.time_compile)
+exclusive(node::InferenceTimingNode; kwargs...) = exclusive(node.ci; kwargs...)
+
+
+precompile(start_tracking, ())
+precompile(stop_tracking, ())
+precompile(timingtree, (Vector{CodeInstance},))

--- a/SnoopCompileCore/src/snoop_inference.jl
+++ b/SnoopCompileCore/src/snoop_inference.jl
@@ -86,7 +86,7 @@ struct InferenceTimingNode
     end
 end
 
-function timingtree(cis, backtraces)
+function timingtree(cis, _backtraces::Vector{Any})
     root = InferenceTimingNode(Core.Compiler.Timings.ROOTmi.cache, nothing)
     # the cis are added in the order children-before-parents, we need to be able to reverse that
     # We index on MethodInstance rather than CodeInstance, because constprop can result in a distinct
@@ -102,7 +102,12 @@ function timingtree(cis, backtraces)
             end
         end
     end
-    backtraces = Dict{CodeInstance,Vector{Union{Ptr{Nothing}, Base.InterpreterIP}}}(ci => bt for (ci, bt) in backtraces)
+    backtraces = Dict{CodeInstance,Vector{Union{Ptr{Nothing}, Base.InterpreterIP}}}()
+    for i = 1:2:length(_backtraces)
+        ci, trace = _backtraces[i], _backtraces[i+1]
+        bt = Base._reformat_bt(trace[1], trace[2])
+        backtraces[ci] = bt
+    end
     addchildren!(root, cis, backedges, miidx, backtraces)
     return root
 end

--- a/SnoopCompileCore/src/snoop_inference.jl
+++ b/SnoopCompileCore/src/snoop_inference.jl
@@ -162,9 +162,15 @@ methodinstance(ci::CodeInstance) = Core.Compiler.get_ci_mi(ci)
 Return the time spent inferring `ci` and its callees.
 If `include_llvm` is true, the LLVM compilation time is added as well.
 """
-inclusive(ci::CodeInstance; include_llvm::Bool=true) = reinterpret(Float16, ci.time_infer_total) +
-    include_llvm * reinterpret(Float16, ci.time_compile)
-inclusive(node::InferenceTimingNode; kwargs...) = inclusive(node.ci; kwargs...)
+inclusive(ci::CodeInstance; include_llvm::Bool=true) = Float64(reinterpret(Float16, ci.time_infer_total)) +
+    include_llvm * Float64(reinterpret(Float16, ci.time_compile))
+function inclusive(node::InferenceTimingNode; kwargs...)
+    t = inclusive(node.ci; kwargs...)
+    for child in node.children
+        t += inclusive(child; kwargs...)
+    end
+    return t
+end
 
 """
     exclusive(ci::InferenceTimingNode; include_llvm::Bool=true)
@@ -172,8 +178,8 @@ inclusive(node::InferenceTimingNode; kwargs...) = inclusive(node.ci; kwargs...)
 Return the time spent inferring `ci`, not including the time needed for any of its callees.
 If `include_llvm` is true, the LLVM compilation time is added.
 """
-exclusive(ci::CodeInstance; include_llvm::Bool=true) = reinterpret(Float16, ci.time_infer_self) +
-    include_llvm * reinterpret(Float16, ci.time_compile)
+exclusive(ci::CodeInstance; include_llvm::Bool=true) = Float64(reinterpret(Float16, ci.time_infer_self)) +
+    include_llvm * Float64(reinterpret(Float16, ci.time_compile))
 exclusive(node::InferenceTimingNode; kwargs...) = exclusive(node.ci; kwargs...)
 
 

--- a/docs/src/tutorials/invalidations.md
+++ b/docs/src/tutorials/invalidations.md
@@ -156,6 +156,9 @@ tree = trees[1]
 
 Each tree stems from a single *cause* described in the top line. For this tree, the cause was adding the new method `score(::Char)` in `BlackjackFacecards`.
 
+!!! note
+    A tree with no cause indicates that the cause occurred before you turned on snooping.
+
 Each *cause* is associated with one or more *victims* of invalidation, a list here named `mt_backedges`. Let's extract the final (and in this case, only) victim:
 
 ```@repl tutorial-invalidations

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -41,6 +41,7 @@ using InteractiveUtils
 using Serialization
 using Printf
 using OrderedCollections
+using CodeTracking
 import YAML  # For @snoop_llvm
 
 using Base: specializations
@@ -73,6 +74,7 @@ end
 
 include("parcel_snoop_inference.jl")
 include("inference_demos.jl")
+export InferenceTiming, InferenceTimingNode
 export exclusive, inclusive, flamegraph, flatten, accumulate_by_source, collect_for, runtime_inferencetime, staleinstances
 export InferenceTrigger, inference_triggers, callerinstance, callingframe, skiphigherorder, trigger_tree, suggest, isignorable
 export report_callee, report_caller, report_callees

--- a/src/SnoopCompile.jl
+++ b/src/SnoopCompile.jl
@@ -85,8 +85,8 @@ export read_snoop_llvm
 include("invalidations.jl")
 export uinvalidated, invalidation_trees, filtermod, findcaller
 
-# include("invalidation_and_inference.jl")
-# export precompile_blockers
+include("invalidation_and_inference.jl")
+export precompile_blockers
 
 # Write
 include("write.jl")

--- a/src/inference_demos.jl
+++ b/src/inference_demos.jl
@@ -81,7 +81,7 @@ This does not require any new inference for `calldouble2` or `calldouble1`, but 
 See [`inference_triggers`](@ref) to see what gets collected and returned.
 """
 function itrigs_demo()
-    eval(:(
+    mod = eval(:(
         module ItrigDemo
         @noinline double(x) = 2x
         @inline calldouble1(c) = double(c[1])
@@ -91,10 +91,11 @@ function itrigs_demo()
     ))
     # Call once to infer `calldouble2(::Vector{Vector{Any}})`, `calldouble1(::Vector{Any})`, `double(::Int)`
     cc = [Any[1]]
-    Base.invokelatest(ItrigDemo.calleach, [cc,cc])
+    f = invokelatest(getglobal, mod, :calleach)
+    Base.invokelatest(f, [cc,cc])
     # Now use UInt8 & Float64 elements to force inference on double, without forcing new inference on its callers
     cc1, cc2 = [Any[0x01]], [Any[1.0]]
-    return @snoop_inference Base.invokelatest(ItrigDemo.calleach, [cc1, cc2])
+    return @snoop_inference Base.invokelatest(f, [cc1, cc2])
 end
 
 """
@@ -137,7 +138,7 @@ which forces inference for `double(::Float64)`.
 See [`skiphigherorder`](@ref) for an example using this demo.
 """
 function itrigs_higherorder_demo()
-    eval(:(
+    mod = eval(:(
         module ItrigHigherOrderDemo
         double(x) = 2x
         @noinline function mymap!(f, dst, src)
@@ -150,10 +151,11 @@ function itrigs_higherorder_demo()
         callmymap(src) = mymap(double, src)
         end
     ))
+    f = invokelatest(getglobal, mod, :callmymap)
     # Call once to infer `callmymap(::Vector{Any})`, `mymap(::typeof(double), ::Vector{Any})`,
     #    `mymap!(::typeof(double), ::Vector{Any}, ::Vector{Any})` and `double(::Int)`
-    Base.invokelatest(ItrigHigherOrderDemo.callmymap, Any[1, 2])
+    Base.invokelatest(f, Any[1, 2])
     src = Any[1.0, 2.0]   # double not yet inferred for Float64
-    return @snoop_inference Base.invokelatest(ItrigHigherOrderDemo.callmymap, src)
+    return @snoop_inference Base.invokelatest(f, src)
 end
 

--- a/src/inference_demos.jl
+++ b/src/inference_demos.jl
@@ -30,7 +30,7 @@ It then returns the results of
 See [`flatten`](@ref) for an example usage.
 """
 function flatten_demo()
-    eval(:(
+    mod = eval(:(
         module FlattenDemo
         struct MyType{T} x::T end
         extract(y::MyType) = y.x
@@ -46,7 +46,8 @@ function flatten_demo()
         end
     ))
     z = (1 + 1)*1 + 2*1 + 5
-    return @snoop_inference Base.invokelatest(FlattenDemo.packintype, 1)
+    packintype = invokelatest(getglobal, mod, :packintype)
+    return @snoop_inference Base.invokelatest(packintype, 1)
 end
 
 """

--- a/test/extensions/jet.jl
+++ b/test/extensions/jet.jl
@@ -1,0 +1,26 @@
+using SnoopCompileCore
+using SnoopCompile
+using Test
+using JET, Cthulhu
+
+@testset "JET integration" begin
+    function mysum(c)   # vendor a simple version of `sum`
+        isempty(c) && return zero(eltype(c))
+        s = first(c)
+        for x in Iterators.drop(c, 1)
+            s += x
+        end
+        return s
+    end
+    call_mysum(cc) = mysum(cc[1])
+
+    cc = Any[Any[1,2,3]]
+    tinf = @snoop_inference call_mysum(cc)
+    rpt = @report_call call_mysum(cc)
+    @test isempty(JET.get_reports(rpt))
+    itrigs = inference_triggers(tinf)
+    irpts = report_callees(itrigs)
+    @test only(irpts).first == last(itrigs)
+    @test !isempty(JET.get_reports(only(irpts).second))
+    @test  isempty(JET.get_reports(report_caller(itrigs[end])))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using SnoopCompile
 
 if !isempty(ARGS)
     "cthulhu" ∈ ARGS && include("extensions/cthulhu.jl")
+    "jet" ∈ ARGS && include("extensions/jet.jl")
 else
     include("snoop_inference.jl")
     include("snoop_llvm.jl")

--- a/test/snoop_inference.jl
+++ b/test/snoop_inference.jl
@@ -13,6 +13,12 @@ using Pkg
 
 using SnoopCompile.FlameGraphs.AbstractTrees  # For FlameGraphs tests
 
+# In case methods have been invalidated
+precompile(SnoopCompileCore.start_tracking, ())
+precompile(SnoopCompileCore.stop_tracking, ())
+precompile(SnoopCompileCore.timingtree, (Vector{Core.CodeInstance}, Vector{Any}))
+
+
 # Constant-prop works differently on different Julia versions.
 # This utility lets you strip frames that const-prop a number.
 hasconstpropnumber(f::SnoopCompile.InferenceTiming) = false # FIXME

--- a/test/snoop_inference.jl
+++ b/test/snoop_inference.jl
@@ -15,8 +15,7 @@ using SnoopCompile.FlameGraphs.AbstractTrees  # For FlameGraphs tests
 
 # Constant-prop works differently on different Julia versions.
 # This utility lets you strip frames that const-prop a number.
-hasconstpropnumber(f::SnoopCompileCore.InferenceTiming) = hasconstpropnumber(f.mi_info)
-hasconstpropnumber(mi_info::Core.Compiler.Timings.InferenceFrameInfo) = any(t -> isa(t, Core.Const) && isa(t.val, Number), mi_info.slottypes)
+hasconstpropnumber(f::SnoopCompile.InferenceTiming) = false # FIXME
 
 @testset "@snoop_inference" begin
     # WARMUP (to compile all the small, reachable methods)
@@ -44,7 +43,7 @@ hasconstpropnumber(mi_info::Core.Compiler.Timings.InferenceFrameInfo) = any(t ->
     @test SnoopCompile.isROOT(Core.MethodInstance(tinf))
     @test SnoopCompile.isROOT(Method(tinf))
     child = tinf.children[1]
-    @test convert(SnoopCompile.InferenceTiming, child).inclusive_time > 0
+    @test inclusive(child) > 0
     @test SnoopCompile.getroot(child.children[1]) == child
     @test SnoopCompile.getroot(child.children[1].children[1]) == child
     @test isempty(staleinstances(tinf))
@@ -67,7 +66,7 @@ hasconstpropnumber(mi_info::Core.Compiler.Timings.InferenceFrameInfo) = any(t ->
     @test length(filter(!hasconstpropnumber, flatten(tinf, tmin=longest_frame_time))) == 1
 
     frames_unsorted = filter(!hasconstpropnumber, flatten(tinf; sortby=nothing))
-    ifi = frames_unsorted[1].mi_info
+    ifi = InferenceTiming(frames_unsorted[1])
     @test SnoopCompile.isROOT(Core.MethodInstance(ifi))
     @test SnoopCompile.isROOT(Method(ifi))
     names = [Method(frame).name for frame in frames_unsorted]
@@ -87,9 +86,7 @@ hasconstpropnumber(mi_info::Core.Compiler.Timings.InferenceFrameInfo) = any(t ->
     iframes = flatten(tinf; sortby=inclusive)
     @test issorted(iframes; by=inclusive)
 
-    t = map(inclusive, frames_unsorted)
-    @test t[2] >= t[3] >= t[4]
-    ifi = frames_unsorted[2].mi_info
+    ifi = InferenceTiming(frames_unsorted[2])
     @test Core.MethodInstance(ifi).def == Method(ifi) == which(M.g, (Int,))
     names = [Method(frame).name for frame in frames_unsorted]
     argtypes = [MethodInstance(frame).specTypes.parameters[2] for frame in frames_unsorted[2:end]]
@@ -112,7 +109,12 @@ hasconstpropnumber(mi_info::Core.Compiler.Timings.InferenceFrameInfo) = any(t ->
     frames = flatten(tinfmod)
     timesm = accumulate_by_source(frames)
     timesmod = filter(pr -> isa(pr[2], Core.MethodInstance), timesm)
-    @test length(timesmod) == 1
+    # We used to be able to record inference of module-level thunks, but that seems gone.
+    # This might be a simpler and more robust test:
+    # thk = Meta.lower(Main, :(for i = 1:2 M.g(2) end))   # creates a :thunk Expr
+    # tinfmod = @snoop_inference ccall(:jl_toplevel_eval_in, Any, (Any, Any), M, thk)
+    # (This is enough to pass the test on Julia 1.10 but not 1.12)
+    @test_broken length(timesmod) == 1
 end
 
 # For the higher-order function attribution test, we need to prevent `f2`
@@ -149,7 +151,7 @@ fdouble(x) = 2x
     mis = callerinstance.(itrigs)
     @test only(mis).def == which(g, (Any,))
     @test callingframe(itrig).callerframes[1].func === :eval
-    @test_throws ArgumentError("it seems you've supplied a child node, but backtraces are collected only at the entrance to inference") inference_triggers(tinf.children[1])
+    @test_throws "it seems you've supplied a child node, but backtraces are collected only at the entrance to inference" inference_triggers(tinf.children[1])
     @test stacktrace(itrig) isa Vector{StackTraces.StackFrame}
     itrig0 = itrig
     counter = 0
@@ -627,9 +629,9 @@ end
 
     fg = SnoopCompile.flamegraph(tinf)
     fgnodes = collect(AbstractTrees.PreOrderDFS(fg))
-    for tgtname in (:h, :i, :+)
+    for tgtname in (:h, :i)
         @test mapreduce(|, fgnodes; init=false) do node
-            node.data.sf.linfo.def.name == tgtname
+            SnoopCompile.methodinstance(node.data.sf.linfo).def.name == tgtname
         end
     end
     # Test that the span covers the whole tree, and check for const-prop
@@ -653,6 +655,33 @@ end
     @test endswith(string(fg.child.data.sf.func), ".g") && endswith(string(fg1.child.data.sf.func), ".h")
     fg2 = flamegraph(tinf.children[2])
     @test endswith(string(fg2.child.data.sf.func), ".i")
+
+    # Precise constprop
+    M = Module()
+    @eval M begin
+        using Random
+        function likescp(x::Int)
+            x == 1 && return "a"
+            x == 2 && return "b"
+            return randstring(x)
+        end
+        llcp(x) = length(likescp(x))
+        Base.@constprop :none nocp(x) = length(likescp(x))
+        f() = llcp(1) + llcp(2) + llcp(5)
+        g() = nocp(1) + nocp(2) + nocp(5)
+    end
+    tinf = @snoop_inference begin
+        M.g()   # call the version with no constprop first
+        M.f()
+    end
+    @test length(tinf.children) == 2
+    node1 = tinf.children[1].children[1].children[1]
+    node2 = tinf.children[2].children[1].children[1]
+    @test node1.ci != node2.ci
+    @test node1.ci.inferred !== nothing
+    @test node2.ci.inferred === nothing
+    @test node1.ci.def == node2.ci.def
+    @test node1.ci.def.def.name === :likescp
 
     # Printing
     M = Module()

--- a/test/snoop_inference.jl
+++ b/test/snoop_inference.jl
@@ -941,27 +941,3 @@ end
 
     Pkg.activate(cproj)
 end
-
-using JET, Cthulhu
-
-@testset "JET integration" begin
-    function mysum(c)   # vendor a simple version of `sum`
-        isempty(c) && return zero(eltype(c))
-        s = first(c)
-        for x in Iterators.drop(c, 1)
-            s += x
-        end
-        return s
-    end
-    call_mysum(cc) = mysum(cc[1])
-
-    cc = Any[Any[1,2,3]]
-    tinf = @snoop_inference call_mysum(cc)
-    rpt = @report_call call_mysum(cc)
-    @test isempty(JET.get_reports(rpt))
-    itrigs = inference_triggers(tinf)
-    irpts = report_callees(itrigs)
-    @test only(irpts).first == last(itrigs)
-    @test !isempty(JET.get_reports(only(irpts).second))
-    @test  isempty(JET.get_reports(report_caller(itrigs[end])))
-end

--- a/test/snoop_inference.jl
+++ b/test/snoop_inference.jl
@@ -13,12 +13,6 @@ using Pkg
 
 using SnoopCompile.FlameGraphs.AbstractTrees  # For FlameGraphs tests
 
-# In case methods have been invalidated
-precompile(SnoopCompileCore.start_tracking, ())
-precompile(SnoopCompileCore.stop_tracking, ())
-precompile(SnoopCompileCore.timingtree, (Vector{Core.CodeInstance}, Vector{Any}))
-
-
 # Constant-prop works differently on different Julia versions.
 # This utility lets you strip frames that const-prop a number.
 hasconstpropnumber(f::SnoopCompile.InferenceTiming) = false # FIXME

--- a/test/testmodules/Invalidation/Project.toml
+++ b/test/testmodules/Invalidation/Project.toml
@@ -16,4 +16,6 @@ InvalidD = {path = "InvalidD"}
 InvalidE = {path = "InvalidE"}
 PkgC = {path = "PkgC"}
 PkgD = {path = "PkgD"}
-PrecompileTools = {path = "/home/tim/.julia/dev/PrecompileTools"}
+
+[compat]
+PrecompileTools = "1.3"

--- a/test/testmodules/Stale/Project.toml
+++ b/test/testmodules/Stale/Project.toml
@@ -2,3 +2,8 @@
 StaleA = "daf834c3-b832-4a67-a95b-01ec1ffe9b4d"
 StaleB = "af730a9e-e668-4d07-a0f0-de54196c2067"
 StaleC = "f6b5ece7-60fa-49fc-ba7e-b783050e37f1"
+
+[sources]
+StaleA = {path = "StaleA"}
+StaleB = {path = "StaleB"}
+StaleC = {path = "StaleC"}


### PR DESCRIPTION
This leverages the [new timing fields of `CodeInstance`](https://github.com/JuliaLang/julia/pull/57074) to replace the old `Core.Compiler.Timings` module. There is a bit of loss particularly in the domain of constant-propagation, which is illustrated in https://gist.github.com/timholy/9a64b27c1932bb414e69b8fe48284b5e. (Read `testcase.jl` before looking at the results.) As a consequence there are a small handful of failing tests locally, but the vast majority pass.

This requires https://github.com/JuliaLang/julia/pull/58124 or alternatively (with some modification to this PR) https://github.com/JuliaLang/julia/pull/58123.
