### PR TITLE
Fix Cthulhu tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,15 @@ jobs:
       - uses: julia-actions/julia-runtest@latest
         with:
           coverage: false    # FIXME: this is very sad, but coverage changes the snoop_inference.jl/Stale tests (as of Julia 1.13.0-DEV.1058)
-      - run: julia  --check-bounds=yes --project -e 'using Pkg; Pkg.test(; test_args=["cthulhu"], coverage=true)'
-      - run: julia  --check-bounds=yes --project -e 'using Pkg; Pkg.test(; test_args=["jet"], coverage=true)'
+      - run: julia  --check-bounds=yes --project -e 'using Pkg; Pkg.test(; test_args=["cthulhu"], coverage=false)'
+      - run: julia  --check-bounds=yes --project -e 'using Pkg; Pkg.test(; test_args=["jet"], coverage=false)'
         continue-on-error: true   # JET test is non-fatal
-      - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: src,SnoopCompileCore/src
-      - uses: codecov/codecov-action@v5
-        with:
-          file: lcov.info
+      # - uses: julia-actions/julia-processcoverage@v1
+      #   with:
+      #     directories: src,SnoopCompileCore/src
+      # - uses: codecov/codecov-action@v5
+      #   with:
+      #     file: lcov.info
 
   skip:
     if: "contains(github.event.head_commit.message, '[skip ci]')"

--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ SCPyPlotExt = "PyPlot"
 [compat]
 AbstractTrees = "0.4"
 CodeTracking = "1.3.9, 2"
-Cthulhu = "2"
+Cthulhu = "2.17.6"
 FlameGraphs = "1"
 InteractiveUtils = "1"
 JET = "0.9"

--- a/ext/CthulhuExt.jl
+++ b/ext/CthulhuExt.jl
@@ -1,8 +1,7 @@
 module CthulhuExt
-    import Cthulhu
+    using Cthulhu: Cthulhu
     using Core: MethodInstance
     using SnoopCompile: InstanceNode, TriggerNode, Suggested, InferenceTrigger, countchildren, callingframe, callerinstance
-
 
     # Originally from invalidations.jl
     Cthulhu.backedges(node::InstanceNode) = sort(node.children; by=countchildren, rev=true)

--- a/test/extensions/cthulhu.jl
+++ b/test/extensions/cthulhu.jl
@@ -2,15 +2,9 @@ module CthulhuExtTest
 
 using SnoopCompileCore, SnoopCompile
 using Cthulhu
+using Cthulhu.Testing
 using Pkg
 using Test
-
-if !isdefined(@__MODULE__, :fake_terminal)
-    @eval (@__MODULE__) begin
-        Base.include(@__MODULE__, normpath(pkgdir(Cthulhu), "test", "FakeTerminals.jl"))
-        using .FakeTerminals
-    end
-end
 
 macro with_try_stderr(out, expr)
     quote
@@ -32,6 +26,15 @@ function f(x)
 end
 g(c) = myplus(f(c[1]), f(c[2]))
 
+cread1(terminal) = readuntil(terminal.output, ')'; keep=true)
+cread(terminal, until) = cread(terminal, "", until)
+cread(terminal, str, until) = occursin(until, str) ? str : cread(terminal, str * cread1(terminal), until)
+strip_ansi_escape_sequences(str) = replace(str, r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])" => "")
+function read_from(terminal, until)
+    displayed = cread(terminal, until)
+    text = strip_ansi_escape_sequences(displayed)
+    return (displayed, text)
+end
 
 @testset "Cthulhu extension" begin
     @testset "ascend for invalidations" begin
@@ -47,23 +50,24 @@ g(c) = myplus(f(c[1]), f(c[2]))
                     using PkgD
                 end
             end
-            tree = only(invalidation_trees(invalidations))
+            trees = invalidation_trees(invalidations)
+            tree = last(trees)
             sig, root = only(tree.mt_backedges)
 
-            fake_terminal() do term, in, out, _
-                t = @async begin
-                    @with_try_stderr out ascend(term, root; interruptexc=false)
+            term = FakeTerminal()
+            t = @async begin
+                @with_try_stderr term.output redirect_stderr(term.error) do
+                    ascend(term, root)
                 end
-                lines = String(readavailable(out))   # this gets the header
-                sleep(0.1)   # some platforms seem to need this
-                lines = String(readavailable(out))
-                sleep(0.1)
-                @test occursin("call_nbits", lines)
-                @test occursin("map_nbits(::Vector{Integer})", lines)
-                # the job of the extension is done  once we've written the menu, so we can quit here
-                write(in, 'q')
-                wait(t)
             end
+            displayed, text = read_from(term, "map_nbits")
+            @test occursin("call_nbits", text)
+            @test occursin("map_nbits(::Vector{Integer})", text)
+            # the job of the extension is done once we've written the menu, so we can quit here
+            write(term.input, 'q')
+            readavailable(term.output)
+            wait(t)
+            finalize(term)
         end
 
         Pkg.activate(cproj)
@@ -74,21 +78,19 @@ g(c) = myplus(f(c[1]), f(c[2]))
         itrigs = inference_triggers(tinf; exclude_toplevel=false)
         itrig = last(itrigs)
 
-        fake_terminal() do term, in, out, _
-            t = @async begin
-                @with_try_stderr out ascend(term, itrig; interruptexc=false)
-            end
-            lines = String(readavailable(out))   # this gets the header
-            sleep(0.1)
-            lines = String(readavailable(out))
-            sleep(0.1)
-            @test occursin("myplus(::UInt8, ::Float16)", lines)
-            @test occursin("g(::Vector{Float64})", lines)
-            # the job of the extension is done  once we've written the menu, so we can quit here
-            write(in, 'q')
-            wait(t)
+        term = FakeTerminal()
+        t = @async begin
+            @with_try_stderr term.output ascend(term, itrig; interruptexc=false)
         end
+        displayed, text = read_from(term, "g(::Vector{Float64})")
+        @test occursin("myplus(::UInt8, ::Float16)", text)
+        @test occursin("g(::Vector{Float64})", text)
+        # the job of the extension is done once we've written the menu, so we can quit here
+        write(term.input, 'q')
+        readavailable(term.output)
+        wait(t)
+        finalize(term)
     end
 end
 
-end
+end # module


### PR DESCRIPTION
`FakeTerminals` got reworked, so the tests here need to be updated.

Coverage is turned off because having it on throws away precompiled code on 1.12, and that causes test failures.