### PR TITLE
snoop_inference: break cycles

### DIFF
--- a/SnoopCompileCore/src/snoop_inference.jl
+++ b/SnoopCompileCore/src/snoop_inference.jl
@@ -134,6 +134,7 @@ function addchildren!(parent::InferenceTimingNode, cis, backedges, miidx, backtr
         while true
             found = false
             for k in backedges[j]
+                k < j && continue   # don't get caught in cycles
                 be = cis[k]
                 if be ∉ handled
                     j = k
@@ -141,7 +142,7 @@ function addchildren!(parent::InferenceTimingNode, cis, backedges, miidx, backtr
                     break
                 end
             end
-            found || break
+            found || break  # quit when no unhandled backedge found
         end
         be ∈ handled && continue
         # bt1, bt2 = get(backtraces, Core.Compiler.get_ci_mi(be), (nothing, nothing))

--- a/test/snoop_inference.jl
+++ b/test/snoop_inference.jl
@@ -855,6 +855,23 @@ end
     # pgdsgui(axs[2], rit; bystr="Inclusive", consts=true, interactive=false)
 end
 
+function countdown(io::IO, n::Int)
+    if n > 0
+        printdown(io, n)
+    end
+    return nothing
+end
+function printdown(io::IO, n::Int)
+    println(io, n)
+    countdown(io, n - 1)
+end
+@testset "cycles" begin
+    tinf = @snoop_inference countdown(IOBuffer(), 3)
+    names = [Method(frame).name for frame in flatten(tinf)]
+    @test :countdown ∈ names
+    @test :printdown ∈ names
+end
+
 @testset "Stale and precompile_blockers" begin
     cproj = Base.active_project()
     cd(joinpath("testmodules", "Stale")) do


### PR DESCRIPTION
Call-graphs that contain cycles were causing
`SnoopCompileCore.addchildren!` to get stuck in an infinite loop.