### PR TITLE
Fix potential inifinite loop in `add_children!()`

### DIFF
--- a/SnoopCompileCore/src/snoop_inference.jl
+++ b/SnoopCompileCore/src/snoop_inference.jl
@@ -134,7 +134,7 @@ function addchildren!(parent::InferenceTimingNode, cis, backedges, miidx, backtr
         while true
             found = false
             for k in backedges[j]
-                k < j && continue   # don't get caught in cycles
+                k ≤ j && continue   # don't get caught in cycles
                 be = cis[k]
                 if be ∉ handled
                     j = k

--- a/test/snoop_inference.jl
+++ b/test/snoop_inference.jl
@@ -872,6 +872,23 @@ end
     @test :printdown ∈ names
 end
 
+function countdownrecursive(io::IO, n::Int)
+    if n == 0
+        return printfinal(io)
+    end
+    return countdownrecursive(io, n-1)
+end
+function printfinal(io::IO)
+    println(io, "final")
+    return nothing
+end
+@testset "cycles - recursive" begin
+    tinf = @snoop_inference countdownrecursive(IOBuffer(), 3)
+    names = [Method(frame).name for frame in flatten(tinf)]
+    @test :countdownrecursive ∈ names
+    @test :printfinal ∈ names
+end
+
 @testset "Stale and precompile_blockers" begin
     cproj = Base.active_project()
     cd(joinpath("testmodules", "Stale")) do


### PR DESCRIPTION
A method can call itself, so need to skip `k == j` as well as `k < j`.

Fixes #444.