### PR TITLE
Handle `nothing` methods in SCPrettyTablesExt

### DIFF
--- a/ext/SCPrettyTablesExt.jl
+++ b/ext/SCPrettyTablesExt.jl
@@ -32,10 +32,10 @@ function SnoopCompile.report_invalidations(io::IO = stdout;
         Float16(100 * inv / sum_invs)
     end
     meth_name = map(trees) do inv
-        "$(inv.method.name)"
+        isnothing(inv.method) ? "unknown" : "$(inv.method.name)"
     end
     fileinfo = map(trees) do inv
-        "$(process_filename(string(inv.method.file))):$(inv.method.line)"
+        isnothing(inv.method) ? "unknown" : "$(process_filename(string(inv.method.file))):$(inv.method.line)"
     end
 
     table_data = hcat(


### PR DESCRIPTION
This resolves https://github.com/JuliaDebug/SnoopCompile.jl/issues/449 by not trying to access fields of `nothing`, instead showing a fixed string.

Of course, it would be even better to understand where these `nothing` entries come from, but I think doing this obvious fix already helps quite a lot of people. 