### PR TITLE
optimize `addchildren!` by precomputing root indices [AI 🤖]

### DIFF
--- a/SnoopCompileCore/src/snoop_inference.jl
+++ b/SnoopCompileCore/src/snoop_inference.jl
@@ -125,28 +125,24 @@ function addchildren!(parent::InferenceTimingNode, handled::Set{CodeInstance}, m
 end
 
 function addchildren!(parent::InferenceTimingNode, cis, backedges, miidx, backtraces)
+    # Precompute the root index for each ci in O(n).
+    # Since cis is children-before-parents, following backedges to higher indices
+    # leads toward roots. We process in reverse so root_of[k] is ready when needed.
+    root_of = collect(eachindex(cis))
+    for i in reverse(eachindex(cis))
+        for k in backedges[i]
+            k > i || continue
+            root_of[i] = root_of[k]
+            break
+        end
+    end
     handled = Set{CodeInstance}()
     for (i, ci) in pairs(cis)
         ci ∈ handled && continue
-        # Follow the backedges to the root
-        j = i
-        be = ci
-        while true
-            found = false
-            for k in backedges[j]
-                k ≤ j && continue   # don't get caught in cycles
-                be = cis[k]
-                if be ∉ handled
-                    j = k
-                    found = true
-                    break
-                end
-            end
-            found || break  # quit when no unhandled backedge found
-        end
+        # Jump to the precomputed root
+        r = root_of[i]
+        be = cis[r]
         be ∈ handled && continue
-        # bt1, bt2 = get(backtraces, Core.Compiler.get_ci_mi(be), (nothing, nothing))
-        # child = InferenceTimingNode(be, make_stacktrace(bt1, bt2), parent)
         child = InferenceTimingNode(be, get(backtraces, be, nothing), parent)
         push!(handled, be)
         addchildren!(child, handled, miidx)


### PR DESCRIPTION
I've been trying to measure inference time on some MTK.jl code but I find that SnoopCompile just hangs when trying to do so. Doing a Ctrl-C constantly shows it is checking keys in the dictionary in `addchildren!`. To being able to make progress I put an LLM to try optimize this function and this is what it came up with. I'm putting this up in case it is useful for others. WItht his I manage to nicely measure the inference time of the code I was interested in.



<details><summary>AI description of problem / optimization</summary>



## Optimize `addchildren!` root-finding from O(n × depth) to O(n)

### The problem

When profiling inference on large models (e.g. Robot6DOF), `@snoop_inference` hangs in `addchildren!`. The bottleneck is a while-loop that walks up `backedges` one step at a time to find each CI's root. With 50,000+ CodeInstances and deep call chains, this is O(n × depth), with each step doing a hash lookup (`∉ handled`). The result is an apparent hang — interrupted stack traces show `ht_keyindex` inside `addchildren!`.

### The fix

Precompute every CI's root in a single O(n) reverse pass, then do O(1) lookups in the main loop. The rest of the algorithm (forward iteration order, edge-based tree building) is unchanged, preserving correct parent-child assignment.

### How it works

Consider this code being profiled:

```julia
i(x) = x + 5
h(a::Array) = i(a[1]::Integer) + 2
g(y::Integer) = h(Any[y])

@snoop_inference begin
    g(2)
    g(true)
end
```

Julia's inference engine records every `CodeInstance` it infers into a vector `cis`, in **children-before-parents** order (a child's inference completes before its parent's). For `g(2)`, inference descends `g(Int) → h(Vector{Any}) → i(Integer)`, so `i(Integer)` finishes first:

```
Index:  1            2          3       4       5        6
cis = [i(Integer),  h(Vec…),  g(Int), i(Int), g(Bool), i(Bool)]
       ──── g(2) subtree ────  ╌╌╌╌╌  ── g(true) ──   ╌╌╌╌╌╌
```

(`i(Int)` and `i(Bool)` are inferred separately — they don't appear in any parent's edges, so they're independent roots.)

#### Building `backedges`

We scan each CI's edges (its callees) and record reverse pointers:

```
cis[2].edges contains i(Integer)  →  backedges[1] = [2]   (h calls i(Integer))
cis[3].edges contains h           →  backedges[2] = [3]   (g(Int) calls h)
cis[5].edges contains h           →  backedges[2] = [3,5] (g(Bool) also calls h!)
```

So `backedges[i]` = "who in `cis` has `cis[i]` as a callee?" — these point **upward** (to higher indices, toward parents).

#### The old algorithm: O(n × depth) backedge walking

For each unhandled CI, the old code walked up backedges one step at a time to find the root:

```
i=1: i(Integer) not handled.
     Walk: backedges[1]=[2] → j=2, backedges[2]=[3,5] → j=3, backedges[3]=[] → stop.
     Root = cis[3] = g(Int). Process g(Int), edge-walk marks {g(Int), h, i(Integer)} handled.
     Cost: 3 steps.

i=2: h — handled, skip.
i=3: g(Int) — handled, skip.
i=4: i(Int) — no backedges → root = self. Process. Cost: 0 steps.
i=5: g(Bool) not handled.
     Walk: backedges[5]=[] → stop. Root = self.
     Process g(Bool), edge-walk marks {g(Bool)} handled.

i=6: i(Bool) — no backedges → root = self. Process.
```

This works, but the walk at `i=1` traversed 3 steps. In a real codebase with 50,000 CIs and call chains hundreds deep, **every leaf walks the full chain**, giving O(n × depth) total steps — each doing a hash lookup (`∉ handled`). That's what caused the hang.

#### The new algorithm: O(n) precomputed roots

**Step 1: Precompute `root_of` in reverse.**

Process indices from high to low. For each index, follow the **first** backedge to a higher index and inherit its (already computed) root:

```
i=6: backedges[6] = []. No k > 6.              root_of[6] = 6  (self)
i=5: backedges[5] = []. No k > 5.              root_of[5] = 5  (self)
i=4: backedges[4] = []. No k > 4.              root_of[4] = 4  (self)
i=3: backedges[3] = []. No k > 3.              root_of[3] = 3  (self)
i=2: backedges[2] = [3, 5]. First k>2 is 3.    root_of[2] = root_of[3] = 3
i=1: backedges[1] = [2]. First k>1 is 2.       root_of[1] = root_of[2] = 3
```

Result:

```
root_of = [3, 3, 3, 4, 5, 6]
            ↑  ↑  ↑  ↑  ↑  ↑
           g  g  g  self self self
          (Int)
```

The key line is `root_of[i] = root_of[k]` — since `k > i` and we process in reverse, `root_of[k]` is already the **transitive** root. This is essentially path compression in one pass: index 1 doesn't need to walk 1→2→3, it just looks up `root_of[2]` which already says 3.

**Step 2: Forward iteration with O(1) root lookup.**

```
i=1: i(Integer) not handled. root_of[1]=3, be=cis[3]=g(Int). Not handled.
     Create g(Int) node. Edge-walk: g(Int).edges → {getindex, h} → h.edges → {i(Integer)}.
     Handled: {g(Int), getindex, h, i(Integer)}.

i=2: h — handled, skip.
i=3: g(Int) — handled, skip.

i=4: i(Int) not handled. root_of[4]=4, be=cis[4]=i(Int). Not handled.
     Create i(Int) node (root-level). Handled += {i(Int)}.

i=5: g(Bool) not handled. root_of[5]=5, be=cis[5]=g(Bool). Not handled.
     Create g(Bool) node. Edge-walk: g(Bool).edges → {getindex(Bool), h}.
     h is already handled → skip. getindex(Bool) not handled → add.
     Handled += {g(Bool), getindex(Bool)}.

i=6: i(Bool) not handled. root_of[6]=6, be=cis[6]=i(Bool). Not handled.
     Create i(Bool) node (root-level). Handled += {i(Bool)}.
```

Result tree:

```
ROOT
├── g(Int)
│   ├── getindex(Any, Int)
│   └── h(Vector{Any})
│       └── i(Integer)
├── i(Int)
├── g(Bool)
│   └── getindex(Any, Bool)
└── i(Bool)
```

#### Why h ends up under g(Int), not g(Bool)

This is critical. Both `g(Int)` and `g(Bool)` have `h` in their edges. But `g(Int)` is processed **first** (forward iteration, index 3 < 5), so its edge-walk claims `h` and marks it handled. When `g(Bool)` is processed later, it finds `h` already handled and skips it.

The old algorithm preserved this same ordering — it also iterated forward. The new algorithm preserves it too, since only the root-finding was changed (from a while-loop walk to an O(1) lookup), not the iteration order or the edge-walking.

#### Why `root_of` follows the first backedge, not the highest

Index 2 (`h`) has `backedges[2] = [3, 5]` — both `g(Int)` at index 3 and `g(Bool)` at index 5 call `h`. We take the **first** (index 3), not the highest (index 5). This matches the original algorithm's greedy behavior: it iterated over backedges in order and took the first unhandled one. Since backedges are populated by iterating `cis` in order, the first entry is always the lowest-index caller — the one inferred earliest, which is the "correct" parent.

If we took 5 instead, `root_of[2]` would be 5 (`g(Bool)`), and `root_of[1]` would also be 5. Then at `i=1`, we'd process `g(Bool)` first, and its edge-walk would claim `h` — stealing it from `g(Int)`.

### Complexity

- **Precomputation**: O(n) — one pass in reverse, each backedge list scanned until the first valid entry.
- **Main loop**: O(n) — each CI is visited once. The `root_of` lookup is O(1). Each CI enters `handled` at most once.
- **Edge-walking** (`addchildren!` 3-arg): O(total edges) — each edge is examined once across all calls, since handled CIs are skipped.

**Total: O(n + total edges)**, versus the old O(n × depth + total edges).


</details>
